### PR TITLE
Refactor dark mode: replace hard-coded colors with CSS variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,8 @@
 		.spinner {
 			width: 50px;
 			height: 50px;
-			border: 5px solid var(--gray-200);
-			border-top-color: var(--primary-600);
+			border: 5px solid var(--border);
+			border-top-color: var(--primary);
 			border-radius: 50%;
 			animation: spin 1s linear infinite;
 		}
@@ -211,9 +211,9 @@
 			min-width: 48px; /* Minimum touch target */
 			min-height: 48px; /* Minimum touch target */
 			background: transparent;
-			border: 1px solid var(--gray-200);
+			border: 1px solid var(--border);
 			border-radius: var(--radius-lg);
-			color: var(--gray-700);
+			color: var(--text);
 			font-size: 0.75rem;
 			font-weight: 600;
 			cursor: pointer;
@@ -418,12 +418,12 @@
 		}
 
 		th {
-			background: var(--gray-50);
-			color: var(--gray-700);
+			background: var(--bg-secondary);
+			color: var(--text);
 			font-weight: 600;
 			text-align: center;
 			padding: 0.5rem 0.25rem;
-			border-bottom: 2px solid var(--gray-200);
+			border-bottom: 2px solid var(--border);
 			position: sticky;
 			top: 0;
 			z-index: 10;
@@ -433,7 +433,7 @@
 
 		td {
 			padding: 0.5rem 0.25rem;
-			border-bottom: 1px solid var(--gray-100);
+			border-bottom: 1px solid var(--border);
 			vertical-align: top;
 			text-align: center;
 			font-size: 0.75rem;
@@ -560,11 +560,11 @@
 			width: 100%;
 			padding: 0.75rem;
 			min-height: 48px; /* Touch-friendly minimum */
-			border: 2px solid var(--gray-300);
+			border: 2px solid var(--border);
 			border-radius: var(--radius-lg);
-			background: white;
+			background: var(--card);
 			font-size: 1rem; /* Prevent zoom on iOS */
-			color: var(--gray-700);
+			color: var(--text);
 			cursor: pointer;
 			transition: all 0.2s;
 			-webkit-appearance: none;
@@ -659,13 +659,13 @@
 		}
 
 		.button-secondary {
-			background: var(--gray-100);
-			color: var(--gray-700);
-			border: 1px solid var(--gray-300);
+			background: var(--bg-secondary);
+			color: var(--text);
+			border: 1px solid var(--border);
 		}
 
 		.button-secondary:hover {
-			background: var(--gray-200);
+			background: var(--card-hover);
 			transform: translateY(-1px);
 		}
 
@@ -1046,8 +1046,8 @@
 			}
 			.table-container {
 				border-radius: var(--radius-lg);
-				border: 1px solid var(--gray-200);
-				background: white;
+				border: 1px solid var(--border);
+				background: var(--card);
 			}
 			th {
 				position: sticky;
@@ -1056,7 +1056,7 @@
 			}
 			td, th {
 				padding: 0.5rem 0.4rem;
-				border-bottom: 1px solid var(--gray-100);
+				border-bottom: 1px solid var(--border);
 			}
 			tr:last-child td {
 				border-bottom: 0;
@@ -1112,14 +1112,14 @@
 			scrollbar-width: thin;
 			padding: 0.25rem;
 			-webkit-overflow-scrolling: touch;
-			border-bottom: 1px solid var(--gray-200);
+			border-bottom: 1px solid var(--border);
 			margin-bottom: 0.5rem;
 		}
 		.day-tab {
 			appearance: none;
-			border: 1px solid var(--gray-200);
-			background: white;
-			color: var(--gray-700);
+			border: 1px solid var(--border);
+			background: var(--card);
+			color: var(--text);
 			border-radius: 9999px;
 			padding: 0.5rem 0.75rem;
 			font-size: 0.85rem;
@@ -1128,17 +1128,17 @@
 			flex: 0 0 auto;
 		}
 		.day-tab[aria-selected="true"], .day-tab.active {
-			background: var(--primary-600);
-			border-color: var(--primary-600);
-			color: white;
+			background: var(--primary);
+			border-color: var(--primary);
+			color: var(--bg);
 			box-shadow: var(--shadow-md);
 		}
 
 		/* Flat list styling for mobile class/teacher day view */
 		.timetable-list {
 			border-radius: var(--radius-lg);
-			border: 1px solid var(--gray-200);
-			background: white;
+			border: 1px solid var(--border);
+			background: var(--card);
 			overflow: hidden;
 		}
 		.timetable-row {
@@ -1147,14 +1147,14 @@
 			gap: 0.5rem;
 			align-items: start;
 			padding: 0.5rem 0.6rem;
-			border-bottom: 1px solid var(--gray-100);
+			border-bottom: 1px solid var(--border);
 		}
 		.timetable-row:last-child { border-bottom: 0; }
-		.timetable-row .period-col { color: var(--gray-700); font-weight: 700; font-size: 0.85rem; }
-		.timetable-row .subject-col { font-weight: 600; color: var(--gray-900); }
-		.timetable-row .teacher-col { color: var(--gray-600); font-size: 0.85rem; }
-		.timetable-row.is-current { background: var(--primary-50); }
-		.timetable-row .extra { display: none; grid-column: 1 / -1; color: var(--gray-600); font-size: 0.8rem; }
+		.timetable-row .period-col { color: var(--text); font-weight: 700; font-size: 0.85rem; }
+		.timetable-row .subject-col { font-weight: 600; color: var(--text); }
+		.timetable-row .teacher-col { color: var(--text-secondary); font-size: 0.85rem; }
+		.timetable-row.is-current { background: var(--bg-secondary); }
+		.timetable-row .extra { display: none; grid-column: 1 / -1; color: var(--text-secondary); font-size: 0.8rem; }
 		.timetable-row.expanded .extra { display: block; }
 		@media (max-width: 420px) {
 			.timetable-row { grid-template-columns: 1fr 1fr; }
@@ -1307,11 +1307,11 @@
 		<div class="spinner"></div>
 	</div>
 
-	<div id="print-capture-area" style="display: none; background: white; padding: 0;">
+	<div id="print-capture-area" style="display: none; background: var(--bg); padding: 0;">
 		<div id="print-header">
 			<h1 id="print-header-title">Veer Patta Public School</h1>
 			<h2 id="print-header-subtitle">Timetable</h2>
-			<div style="font-size: 8pt; color: #6b7280; margin-top: 0.25rem;">
+			<div style="font-size: 8pt; color: var(--text-muted); margin-top: 0.25rem;">
 				Generated on <span id="print-date"></span> at <span id="print-time"></span>
 			</div>
 		</div>
@@ -1448,7 +1448,8 @@
 			// Update theme-color meta tag for mobile browsers
 			const themeColorMeta = document.querySelector('meta[name="theme-color"]');
 			if (themeColorMeta) {
-				themeColorMeta.setAttribute('content', mode === 'dark' ? '#1a1a2e' : '#2563eb');
+				const computedColor = getComputedStyle(document.documentElement).getPropertyValue('--card').trim();
+				themeColorMeta.setAttribute('content', computedColor);
 			}
 
 			// Update toggle button icon
@@ -2863,8 +2864,8 @@
 							</div>
 						`;
 					}).join('')
-					: `<div style="color: var(--gray-500); padding: 2rem; text-align: center; border: 2px dashed var(--gray-200); border-radius: var(--radius);">
-					   <i data-lucide="user-x" style="width: 24px; height: 24px; margin-bottom: 0.5rem; color: var(--gray-400);"></i><br>
+					: `<div style="color: var(--text-muted); padding: 2rem; text-align: center; border: 2px dashed var(--border); border-radius: var(--radius);">
+					   <i data-lucide="user-x" style="width: 24px; height: 24px; margin-bottom: 0.5rem; color: var(--text-muted);"></i><br>
 					   No teachers are free for this slot.
 				   </div>`;
 
@@ -2875,56 +2876,56 @@
 				});
 
 				const html = `
-					<div style="background: linear-gradient(135deg, var(--primary-50) 0%, var(--blue-50) 100%); 
+					<div style="background: var(--bg-secondary);
 								padding: 1rem; border-radius: var(--radius-lg); margin-bottom: 1rem;
-								border: 1px solid var(--primary-200);">
+								border: 1px solid var(--border);">
 						<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
 							<div>
-								<strong style="color: var(--primary-700);">Current Time: ${currentTime}</strong>
+								<strong style="color: var(--text);">Current Time: ${currentTime}</strong>
 							</div>
 							<div style="display: flex; align-items: center; gap: 0.5rem;">
 								<div style="width: 8px; height: 8px; background: var(--green-500); border-radius: 50%; animation: pulse 2s infinite;"></div>
-								<small style="color: var(--primary-600); font-weight: 500;">Live Updates</small>
+								<small style="color: var(--text-secondary); font-weight: 500;">Live Updates</small>
 							</div>
 						</div>
-						<small style="color: var(--primary-600);">
+						<small style="color: var(--text-secondary);">
 							Showing free teachers for ${currentDay}, Period ${currentPeriod}
 						</small>
 					</div>
-					
+
 					<div class="grid grid-cols-1 grid-cols-md-2 gap-4 mb-4">
 						<div>
-							<label style="display: block; font-weight: 600; margin-bottom: 0.5rem; color: var(--gray-700);">
+							<label style="display: block; font-weight: 600; margin-bottom: 0.5rem; color: var(--text);">
 								<i data-lucide="calendar" style="width: 16px; height: 16px; display: inline; margin-right: 0.25rem;"></i>
 								Day
 							</label>
-							<select id="finder-day-select" style="border: 2px solid var(--primary-200);">${dayOptions}</select>
+							<select id="finder-day-select" style="border: 2px solid var(--border);">${dayOptions}</select>
 						</div>
 						<div>
-							<label style="display: block; font-weight: 600; margin-bottom: 0.5rem; color: var(--gray-700);">
+							<label style="display: block; font-weight: 600; margin-bottom: 0.5rem; color: var(--text);">
 								<i data-lucide="clock" style="width: 16px; height: 16px; display: inline; margin-right: 0.25rem;"></i>
 								Period
 							</label>
-							<select id="finder-period-select" style="border: 2px solid var(--primary-200);">${periodOptions}</select>
+							<select id="finder-period-select" style="border: 2px solid var(--border);">${periodOptions}</select>
 						</div>
 					</div>
-					
+
 					<div style="max-height: 20rem; overflow-y: auto; padding: 0.5rem;
-								background: var(--gray-50); border-radius: var(--radius-lg);
-								border: 1px solid var(--gray-200);">
+								background: var(--bg-secondary); border-radius: var(--radius-lg);
+								border: 1px solid var(--border);">
 						<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;">
-							<h4 style="color: var(--gray-700); margin: 0;">
+							<h4 style="color: var(--text); margin: 0;">
 								<i data-lucide="users-check" style="width: 18px; height: 18px; display: inline; margin-right: 0.5rem;"></i>
 								Smart Teacher Recommendations
 							</h4>
-							<span style="background: var(--primary-600); color: white; padding: 0.25rem 0.5rem; 
+							<span style="background: var(--primary); color: var(--bg); padding: 0.25rem 0.5rem;
 									 border-radius: var(--radius); font-size: 0.75rem; font-weight: 600;">
 							${freeTeachers.length} available
 						</span>
 						</div>
 						${freeTeachers.length > 0 ? `
-							<div style="background: var(--blue-50); padding: 0.5rem; border-radius: var(--radius); margin-bottom: 0.75rem; border-left: 3px solid var(--blue-500);">
-								<p style="font-size: 0.75rem; color: var(--blue-800); margin: 0;">
+							<div style="background: var(--bg-secondary); padding: 0.5rem; border-radius: var(--radius); margin-bottom: 0.75rem; border-left: 3px solid var(--primary);">
+								<p style="font-size: 0.75rem; color: var(--text-secondary); margin: 0;">
 									<i data-lucide="info" style="width: 12px; height: 12px; display: inline; margin-right: 0.25rem;"></i>
 									Teachers ranked by: Subject expertise → Grade familiarity → Workload balance → Availability
 								</p>
@@ -3003,22 +3004,22 @@
 							Quick Actions
 						</h2>
 						<div class="grid grid-cols-1 grid-cols-md-2 gap-4">
-							<button class="button button-primary" onclick="switchView('Day')" style="background: linear-gradient(135deg, var(--primary-600), var(--primary-700));">
-								<i data-lucide="calendar"></i> 
+							<button class="button button-primary" onclick="switchView('Day')">
+								<i data-lucide="calendar"></i>
 								<span class="mobile-only">Today's Schedule</span>
 								<span class="desktop-only">View Today's Schedule</span>
 							</button>
-							<button class="button button-primary" onclick="switchView('Substitution')" style="background: linear-gradient(135deg, var(--green-500), var(--green-600));">
+							<button class="button button-primary" onclick="switchView('Substitution')" style="background: var(--green-500);">
 								<i data-lucide="user-cog"></i>
 								<span class="mobile-only">Substitutions</span>
 								<span class="desktop-only">Manage Substitutions</span>
 							</button>
-							<button class="button button-secondary" onclick="switchView('Class')" style="background: linear-gradient(135deg, var(--yellow-500), var(--yellow-600)); color: white;">
+							<button class="button button-secondary" onclick="switchView('Class')" style="background: var(--yellow-500); color: var(--bg);">
 								<i data-lucide="school"></i>
 								<span class="mobile-only">Classes</span>
 								<span class="desktop-only">Browse Classes</span>
 							</button>
-							<button class="button button-secondary" onclick="switchView('Teacher')" style="background: linear-gradient(135deg, var(--red-500), var(--red-600)); color: white;">
+							<button class="button button-secondary" onclick="switchView('Teacher')" style="background: var(--red-500); color: var(--bg);">
 								<i data-lucide="users"></i>
 								<span class="mobile-only">Teachers</span>
 								<span class="desktop-only">Teacher Schedules</span>
@@ -3314,7 +3315,7 @@
 					const time = periodHeaders[i]?.time || '';
 					return `
 						<div class="timetable-row ${i===activeIdx?'is-current':''}" data-period-index="${i}" id="row-p${i}" role="button" tabindex="0" onclick="this.classList.toggle('expanded')" onkeypress="if(event.key==='Enter') this.click()">
-							<div class="period-col">${label}<div style="font-weight:500; color: var(--gray-500); font-size: 0.75rem;">${time}</div></div>
+							<div class="period-col">${label}<div style="font-weight:500; color: var(--text-muted); font-size: 0.75rem;">${time}</div></div>
 							<div class="subject-col">${p?.subject || ''}</div>
 							<div class="teacher-col">${p?.teacher || ''}</div>
 						</div>`;
@@ -3346,7 +3347,7 @@
 						`).join('');
 						detailsHtml = `
 							<div class="mt-4">
-								<div style="background: var(--primary-50); color: var(--primary-800); font-weight: 600; text-align: center; border-radius: var(--radius); padding: 0.5rem; margin-bottom: 0.75rem;">
+								<div style="background: var(--bg-secondary); color: var(--text); font-weight: 600; text-align: center; border-radius: var(--radius); padding: 0.5rem; margin-bottom: 0.75rem;">
 									Total Weekly Periods: ${teacherDetails[selectedTeacher].periodCount}
 								</div>
 								<div class="day-tabs" role="tablist" aria-label="Select day">
@@ -3405,7 +3406,7 @@
 
 					detailsHtml = `
 						<div class="mt-4">
-							<div style="background: var(--primary-50); color: var(--primary-800);
+							<div style="background: var(--bg-secondary); color: var(--text);
 										font-weight: 600; text-align: center; border-radius: var(--radius);
 										padding: 0.75rem; margin-bottom: 1.5rem;">
 								Total Weekly Periods: ${teacherDetails[selectedTeacher].periodCount}
@@ -3479,7 +3480,7 @@
 					const p = daySchedule[i];
 					return `
 						<div class="timetable-row ${i===activeIdx?'is-current':''}" data-period-index="${i}" id="row-p${i}" role="button" tabindex="0" onclick="this.classList.toggle('expanded')" onkeypress="if(event.key==='Enter') this.click()">
-							<div class="period-col">${h.name}<div style="font-weight:500; color: var(--gray-500); font-size: 0.75rem;">${h.time||''}</div></div>
+							<div class="period-col">${h.name}<div style="font-weight:500; color: var(--text-muted); font-size: 0.75rem;">${h.time||''}</div></div>
 							<div class="subject-col">${p ? p.subject : ''}</div>
 							<div class="teacher-col">${selectedTeacher}</div>
 							<div class="extra">${p ? ('Class: ' + p.className) : ''}</div>
@@ -3498,10 +3499,10 @@
 				<div style="page-break-inside: avoid;">
 					<table style="width: 100%; font-size: 8pt; border-collapse: collapse;">
 						<thead>
-							<tr style="background: #f3f4f6;">
-								<th style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold;">Class</th>
-								${periodHeaders.map(h => 
-									`<th style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold; text-align: center;">
+							<tr style="background: var(--bg-secondary);">
+								<th style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold;">Class</th>
+								${periodHeaders.map(h =>
+									`<th style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold; text-align: center;">
 										${h.name}<br><span style="font-size: 6pt;">${h.time}</span>
 									</th>`
 								).join('')}
@@ -3512,14 +3513,14 @@
 								if (!timetable[selectedDay][cName]) return '';
 								return `
 									<tr>
-										<td style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold; background: #f9fafb;">${cName}</td>
+										<td style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold; background: var(--bg-secondary);">${cName}</td>
 										${timetable[selectedDay][cName].map((period, i) => {
 											const substitute = daySubs[cName]?.[i];
 											return `
-												<td style="border: 1px solid #d1d5db; padding: 4px 6px; text-align: center;">
+												<td style="border: 1px solid var(--border); padding: 4px 6px; text-align: center;">
 													<div style="font-size: 7pt; font-weight: bold; margin-bottom: 1px;">${period.subject || ''}</div>
 													${period.teacher ? `<div style="font-size: 6pt; ${substitute ? 'text-decoration: line-through; opacity: 0.6;' : ''}">${period.teacher}</div>` : ''}
-													${substitute ? `<div style="font-size: 6pt; color: #2563eb; font-weight: bold;">Sub: ${substitute}</div>` : ''}
+													${substitute ? `<div style="font-size: 6pt; color: var(--primary); font-weight: bold;">Sub: ${substitute}</div>` : ''}
 												</td>
 											`;
 										}).join('')}
@@ -3540,10 +3541,10 @@
 				<div style="page-break-inside: avoid;">
 					<table style="width: 100%; font-size: 8pt; border-collapse: collapse;">
 						<thead>
-							<tr style="background: #f3f4f6;">
-								<th style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold;">Day</th>
-								${periodHeaders.map(h => 
-									`<th style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold; text-align: center;">
+							<tr style="background: var(--bg-secondary);">
+								<th style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold;">Day</th>
+								${periodHeaders.map(h =>
+									`<th style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold; text-align: center;">
 										${h.name}<br><span style="font-size: 6pt;">${h.time}</span>
 									</th>`
 								).join('')}
@@ -3554,11 +3555,11 @@
 								const daySchedule = timetable[day][selectedClass] || [];
 								return `
 									<tr>
-										<td style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold; background: #f9fafb;">${day}</td>
+										<td style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold; background: var(--bg-secondary);">${day}</td>
 										${periodHeaders.map((_, i) => {
 											const period = daySchedule[i];
 											return `
-												<td style="border: 1px solid #d1d5db; padding: 4px 6px; text-align: center;">
+												<td style="border: 1px solid var(--border); padding: 4px 6px; text-align: center;">
 													${period ? `
 														<div style="font-size: 7pt; font-weight: bold; margin-bottom: 1px;">${period.subject}</div>
 														<div style="font-size: 6pt;">${period.teacher || ''}</div>
@@ -3584,18 +3585,18 @@
 			
 			let html = `
 				<div style="page-break-inside: avoid;">
-					<h3 style="text-align: center; margin: 0 0 1rem 0; font-size: 1.2em; color: #2563eb;">
+					<h3 style="text-align: center; margin: 0 0 1rem 0; font-size: 1.2em; color: var(--primary);">
 						Weekly Schedule - ${selectedTeacher}
 					</h3>
-					<div style="text-align: center; margin-bottom: 1rem; font-size: 8pt; color: #6b7280;">
+					<div style="text-align: center; margin-bottom: 1rem; font-size: 8pt; color: var(--text-muted);">
 						Total Weekly Periods: ${teacherData.periodCount}
 					</div>
 					<table style="width: 100%; font-size: 8pt; border-collapse: collapse;">
 						<thead>
-							<tr style="background: #f3f4f6;">
-								<th style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold;">Day</th>
-								${periodHeaders.map(h => 
-									`<th style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold; text-align: center;">${h.name}</th>`
+							<tr style="background: var(--bg-secondary);">
+								<th style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold;">Day</th>
+								${periodHeaders.map(h =>
+									`<th style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold; text-align: center;">${h.name}</th>`
 								).join('')}
 							</tr>
 						</thead>
@@ -3604,11 +3605,11 @@
 								const daySchedule = teacherData.schedule[day] || [];
 								return `
 									<tr>
-										<td style="border: 1px solid #d1d5db; padding: 4px 6px; font-weight: bold; background: #f9fafb;">${day}</td>
+										<td style="border: 1px solid var(--border); padding: 4px 6px; font-weight: bold; background: var(--bg-secondary);">${day}</td>
 										${periodHeaders.map((_, i) => {
 											const period = daySchedule[i];
 											return `
-												<td style="border: 1px solid #d1d5db; padding: 4px 6px; text-align: center;">
+												<td style="border: 1px solid var(--border); padding: 4px 6px; text-align: center;">
 													${period ? `
 														<div style="font-size: 7pt; font-weight: bold; margin-bottom: 1px;">${period.subject}</div>
 														<div style="font-size: 6pt;">${period.className}</div>
@@ -3632,13 +3633,13 @@
 			days.forEach((day, dayIndex) => {
 				html += `
 					<div style="${dayIndex > 0 ? 'page-break-before: always;' : ''} page-break-inside: avoid;">
-						<h3 style="text-align: center; margin: 0 0 1rem 0; font-size: 1.1em; color: #2563eb;">${day}</h3>
+						<h3 style="text-align: center; margin: 0 0 1rem 0; font-size: 1.1em; color: var(--primary);">${day}</h3>
 						<table style="width: 100%; font-size: 7pt; border-collapse: collapse;">
 							<thead>
-								<tr style="background: #f3f4f6;">
-									<th style="border: 1px solid #d1d5db; padding: 3px 4px; font-weight: bold;">Class</th>
-									${periodHeaders.map(h => 
-										`<th style="border: 1px solid #d1d5db; padding: 3px 4px; font-weight: bold; text-align: center;">
+								<tr style="background: var(--bg-secondary);">
+									<th style="border: 1px solid var(--border); padding: 3px 4px; font-weight: bold;">Class</th>
+									${periodHeaders.map(h =>
+										`<th style="border: 1px solid var(--border); padding: 3px 4px; font-weight: bold; text-align: center;">
 											${h.name}<br><span style="font-size: 5pt;">${h.time}</span>
 										</th>`
 									).join('')}
@@ -3649,9 +3650,9 @@
 									if (!timetable[day][cName]) return '';
 									return `
 										<tr>
-											<td style="border: 1px solid #d1d5db; padding: 3px 4px; font-weight: bold; background: #f9fafb;">${cName}</td>
+											<td style="border: 1px solid var(--border); padding: 3px 4px; font-weight: bold; background: var(--bg-secondary);">${cName}</td>
 											${timetable[day][cName].map(period => `
-												<td style="border: 1px solid #d1d5db; padding: 3px 4px; text-align: center;">
+												<td style="border: 1px solid var(--border); padding: 3px 4px; text-align: center;">
 													<div style="font-size: 6pt; font-weight: bold; margin-bottom: 1px;">${period.subject || ''}</div>
 													${period.teacher ? `<div style="font-size: 5pt;">${period.teacher}</div>` : ''}
 												</td>
@@ -3932,14 +3933,14 @@
 					<div class="grid grid-cols-1 gap-6">
 						<div>
 							<label class="block font-bold mb-2">Select Absent Teachers (for ${selectedDay})</label>
-							<div style="border: 1px solid var(--gray-300); border-radius: var(--radius);
+							<div style="border: 1px solid var(--border); border-radius: var(--radius);
 									padding: 0.5rem; max-height: 15rem; overflow-y: auto;">
 								${teacherOptionsHtml}
 							</div>
 						</div>
 					</div>
 					<div class="grid grid-cols-1 grid-cols-md-2 gap-4"
-						 style="border-top: 1px solid var(--gray-200); padding-top: 1.5rem; margin-top: 1.5rem;">
+						 style="border-top: 1px solid var(--border); padding-top: 1.5rem; margin-top: 1.5rem;">
 						<button id="generate-plan-btn" class="button button-primary">
 							<i data-lucide="wand-2"></i> Generate Smart Plan
 						</button>
@@ -4428,10 +4429,10 @@
 				
 				// Add school header
 				tempContainer.innerHTML = `
-					<div style="text-align: center; margin-bottom: 2rem; border-bottom: 2px solid #2563eb; padding-bottom: 1rem;">
-						<h1 style="color: #2563eb; font-size: 1.5rem; margin: 0;">Veer Patta Public School</h1>
-						<p style="color: #6b7280; margin: 0.5rem 0 0 0;">Substitution Plan - ${day}</p>
-						<small style="color: #9ca3af;">Generated on ${new Date().toLocaleDateString('en-GB')} at ${new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}</small>
+					<div style="text-align: center; margin-bottom: 2rem; border-bottom: 2px solid var(--primary); padding-bottom: 1rem;">
+						<h1 style="color: var(--primary); font-size: 1.5rem; margin: 0;">Veer Patta Public School</h1>
+						<p style="color: var(--text-muted); margin: 0.5rem 0 0 0;">Substitution Plan - ${day}</p>
+						<small style="color: var(--text-muted);">Generated on ${new Date().toLocaleDateString('en-GB')} at ${new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}</small>
 					</div>
 					${planContent.innerHTML}
 				`;
@@ -4818,7 +4819,7 @@
 							<i data-lucide="alert-circle" style="width: 48px; height: 48px; margin-bottom: 1rem;"></i><br>
 							<h3>Initialization Error</h3>
 							<p>Failed to load the timetable application. Please refresh the page.</p>
-							<p style="font-size: 0.875rem; color: var(--gray-600); margin-top: 1rem;">
+							<p style="font-size: 0.875rem; color: var(--text-secondary); margin-top: 1rem;">
 								Error details: ${error.message}
 							</p>
 							<button onclick="window.location.reload()" class="button button-primary" style="margin-top: 1rem; max-width: 200px;">

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -135,17 +135,17 @@
    ========================================== */
 
 .color-legend {
-	background: white;
+	background: var(--card);
 	border-radius: 8px;
 	padding: 16px;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 2px 8px var(--shadow-color);
 	margin: 16px 0;
 }
 
 .color-legend-title {
 	font-size: 14px;
 	font-weight: 600;
-	color: var(--gray-900);
+	color: var(--text);
 	margin-bottom: 12px;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
- Updated styles/colors.css color-legend to use --card and --text
- Replaced all static colors (white, #fff, hex codes) with theme variables
- Converted var(--gray-*) and var(--primary-*) to semantic tokens:
  - --bg / --bg-secondary for backgrounds
  - --card / --card-hover for cards and surfaces
  - --text / --text-secondary / --text-muted for text
  - --border / --border-hover for borders
  - --primary / --primary-hover for accents
- Updated meta theme-color to use computed --card variable
- Fixed print styles, table styles, and mobile UI components
- Preserved high-contrast mode and accessibility features
- All changes ensure proper dark mode support throughout the app