### PR TITLE
Fix dark theme select chevron styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1350,12 +1350,16 @@
         }
 
 	/* Fix dropdown styling in dark mode */
-	[data-theme="dark"] select {
-		background: var(--bg-secondary) !important;
-		color: var(--text) !important;
-		border-color: var(--border) !important;
-		background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23e8e8e8' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e") !important;
-	}
+        [data-theme="dark"] select {
+                background-color: var(--bg-secondary) !important;
+                color: var(--text) !important;
+                border-color: var(--border) !important;
+                background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23e8e8e8' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e") !important;
+                background-repeat: no-repeat !important;
+                background-position: right 0.75rem center !important;
+                background-size: 1rem !important;
+                padding-right: 2.5rem !important;
+        }
 
 	/* Ensure dropdown text and options are visible */
 	[data-theme="dark"] select option {


### PR DESCRIPTION
## Summary
- ensure dark theme selects use background-color and explicit background positioning so the chevron renders once

## Testing
- manual dark mode toggle via Playwright

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911d9531578832ea157e39dea1932d0)