### PR TITLE
Improve dark theme nav button contrast

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -274,9 +274,14 @@ textarea,
 }
 
 [data-theme="dark"] .nav-button.active {
-	background: var(--primary);
-	border-color: var(--primary);
-	color: var(--bg);
+        background: var(--primary);
+        border-color: var(--primary);
+        color: var(--text-on-primary);
+}
+
+[data-theme="dark"] .nav-button.active:hover,
+[data-theme="dark"] .nav-button.active:focus-visible {
+        color: var(--text-on-primary);
 }
 
 /* Cards and containers */


### PR DESCRIPTION
## Summary
- use the text-on-primary token for active navigation buttons in dark mode to improve contrast
- ensure hover and focus-visible states for active buttons preserve high-contrast text color

## Testing
- python -m http.server 8000 (manual dark-mode verification)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911da8ef338832ea8288947c5a80840)