### PR TITLE
Fix CSV export table selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -4500,12 +4500,13 @@
 		// New function: Export CSV
 		function handleExportCSV() {
 			try {
-				// Find the current visible table
-				const visibleTable = document.querySelector('.table-container table:not(#print-capture-area table)');
-				if (!visibleTable) {
-					showToast('❌ No table found to export', 3000, 'error');
-					return;
-				}
+                        // Find the current visible table, excluding tables within the print capture area
+                        const tables = document.querySelectorAll('.table-container table');
+                        const visibleTable = Array.from(tables).find(table => !table.closest('#print-capture-area'));
+                        if (!visibleTable) {
+                                showToast('❌ No table found to export', 3000, 'error');
+                                return;
+                        }
 
 				// Convert table to 2D array
 				const data = tableTo2DArray(visibleTable);


### PR DESCRIPTION
## Summary
- update CSV export logic to skip tables inside the print capture area
- keep existing export behaviour when no eligible table is found

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911dd5c0d20832ea1fb6025a165c039)