### PR TITLE
Ensure bottom sheet titles have unique accessible IDs

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -288,6 +288,9 @@
      * });
      * sheet.show();
      */
+    // Track instances so each sheet title receives a unique ID for accessibility attributes.
+    let bottomSheetInstanceCounter = 0;
+
     class ModernBottomSheet {
         /**
          * @param {Object} options - Configuration options
@@ -319,7 +322,9 @@
             sheet.className = 'modern-bottom-sheet';
             sheet.setAttribute('role', 'dialog');
             sheet.setAttribute('aria-modal', 'true');
-            sheet.setAttribute('aria-labelledby', 'bottom-sheet-title');
+            const titleId = `bottom-sheet-title-${++bottomSheetInstanceCounter}`;
+            this.titleId = titleId;
+            sheet.setAttribute('aria-labelledby', titleId);
 
             // Handle for dragging
             const handle = document.createElement('div');
@@ -333,7 +338,7 @@
 
             const title = document.createElement('h2');
             title.className = 'modern-bottom-sheet-title';
-            title.id = 'bottom-sheet-title';
+            title.id = titleId;
             title.textContent = this.options.title;
 
             const closeBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- generate a unique identifier for each ModernBottomSheet instance
- apply the identifier to the dialog's `aria-labelledby` attribute and matching title element

## Testing
- node - <<'NODE'


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911df27ad00832e95c12014e01c17a0)