### PR TITLE
Default color coding flag to enabled

### DIFF
--- a/scripts/colors.js
+++ b/scripts/colors.js
@@ -226,8 +226,39 @@
 	 */
 	function isFeatureEnabled() {
 		try {
-			const value = localStorage.getItem(FEATURE_FLAG);
-			return value === 'true' || value === '1' || value === 'enabled';
+			const storedValue = localStorage.getItem(FEATURE_FLAG);
+
+			if (storedValue !== null && storedValue !== undefined) {
+				const normalizedValue = String(storedValue).trim().toLowerCase();
+
+				if (
+						normalizedValue === 'false' ||
+						normalizedValue === '0' ||
+						normalizedValue === 'disabled' ||
+						normalizedValue === 'off'
+				) {
+					return false;
+				}
+
+				if (
+						normalizedValue === 'true' ||
+						normalizedValue === '1' ||
+						normalizedValue === 'enabled' ||
+						normalizedValue === 'on'
+				) {
+					return true;
+				}
+
+				// Fallback to enabled for unrecognized but existing values
+				return true;
+			}
+
+			const featureFlags = window.FEATURE_FLAGS || {};
+			if (Object.prototype.hasOwnProperty.call(featureFlags, FEATURE_FLAG)) {
+				return Boolean(featureFlags[FEATURE_FLAG]);
+			}
+
+			return true; // Default to enabled when no stored value exists
 		} catch (e) {
 			console.warn('Unable to read feature flag from localStorage:', e);
 			return true; // Default to enabled if localStorage is unavailable


### PR DESCRIPTION
## Summary
- default the color coding feature to enabled when no preference is stored
- honor explicit localStorage disables and optionally read from window.FEATURE_FLAGS

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911df17e8fc832ea0fb445c4c7fdb60)