### PR TITLE
Improve dark mode subject contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -1306,9 +1306,9 @@
 	   ======================================== */
 
 	/* Fix text colors in dark mode for better contrast */
-	[data-theme="dark"] .subject {
-		color: var(--text) !important;
-	}
+        [data-theme="dark"] .subject:not([data-category]):not([class*="subject-color-"]) {
+                color: var(--text) !important;
+        }
 
 	[data-theme="dark"] .teacher {
 		color: var(--text-secondary) !important;

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -11,11 +11,11 @@
    ========================================== */
 
 :root {
-	/* Languages - Blue Shades */
-	--color-languages-bg: #dbeafe;
-	--color-languages-text: #1e3a8a;
-	--color-languages-border: #3b82f6;
-	--color-languages-hover: #bfdbfe;
+        /* Languages - Blue Shades */
+        --color-languages-bg: #dbeafe;
+        --color-languages-text: #1e3a8a;
+        --color-languages-border: #3b82f6;
+        --color-languages-hover: #bfdbfe;
 
 	/* Sciences - Green Shades */
 	--color-sciences-bg: #d1fae5;
@@ -44,8 +44,46 @@
 	/* Default/Neutral - Gray Shades */
 	--color-default-bg: #f3f4f6;
 	--color-default-text: #374151;
-	--color-default-border: #9ca3af;
-	--color-default-hover: #e5e7eb;
+        --color-default-border: #9ca3af;
+        --color-default-hover: #e5e7eb;
+}
+
+[data-theme="dark"] {
+        /* Languages - Blue Shades (Dark Mode) */
+        --color-languages-bg: #10253f;
+        --color-languages-text: #dce9ff;
+        --color-languages-border: #4c91ff;
+        --color-languages-hover: #163257;
+
+        /* Sciences - Green Shades (Dark Mode) */
+        --color-sciences-bg: #0f2b1f;
+        --color-sciences-text: #d6fbe8;
+        --color-sciences-border: #34d399;
+        --color-sciences-hover: #15402c;
+
+        /* Mathematics - Purple Shades (Dark Mode) */
+        --color-math-bg: #201034;
+        --color-math-text: #f1e9ff;
+        --color-math-border: #c084fc;
+        --color-math-hover: #2b1647;
+
+        /* Social Studies - Orange Shades (Dark Mode) */
+        --color-social-bg: #331b07;
+        --color-social-text: #ffe8d0;
+        --color-social-border: #fb923c;
+        --color-social-hover: #44250d;
+
+        /* Sports & Activities - Red Shades (Dark Mode) */
+        --color-sports-bg: #3a0e0e;
+        --color-sports-text: #ffe2e2;
+        --color-sports-border: #f87171;
+        --color-sports-hover: #4c1414;
+
+        /* Default/Neutral (Dark Mode) */
+        --color-default-bg: #252836;
+        --color-default-text: #f4f4f5;
+        --color-default-border: #9ca3af;
+        --color-default-hover: #2f3243;
 }
 
 /* ==========================================


### PR DESCRIPTION
## Summary
- scope the dark-mode subject text override so color-coded subjects retain their themed colors
- introduce dark-mode subject color variables to provide accessible palettes for each category and the legend

## Testing
- `python - <<'PY' ...`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912b4cfed0c832e81ba2277eb6531a9)