### PR TITLE
Align Class 12 Commerce Wednesday language periods

### DIFF
--- a/index.html
+++ b/index.html
@@ -1731,9 +1731,9 @@
 		Class 11 Science,Physics (Phy),Physics (Phy),English (Pradhyuman),Biology (Hemlata),Biology (Hemlata),Sports (Rakesh),Chemistry (Toshit),Chemistry (Toshit)
 		Class 11 Commerce,CCS (Maya),Economics (Prakash),English (Pradhyuman),Self Study (Maya),Accountancy (Nathulal),Accountancy (Nathulal),Business (Nidhika),Sports (Rakesh)
 		Class 11 Arts,English Literature (Harshita),Economics (Prakash),English (Pradhyuman),Geography (Prakash),Self Study (Toshit),Political Science (Pradhyuman),Sports (Rakesh),Sports (Rakesh)
-		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Biology (Hemlata),Hindi (Jainendra),English (Pradhyuman),Sports (Rakesh),Hindi (Jainendra),Hindi (Jainendra)
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),CCS (Maya),Business (Pradhyuman),Hindi (Jainendra),English (Pradhyuman),Accountancy (Nathulal),Sports (Rakesh)
-		Class 12 Arts,Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),Hindi (Jainendra),English (Pradhyuman),English Literature (Harshita),Hindi (Jainendra),Hindi (Jainendra)
+                Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Biology (Hemlata),Hindi (Jainendra),English (Pradhyuman),Sports (Rakesh),Hindi (Jainendra),Hindi (Jainendra)
+                Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),CCS (Maya),Hindi (Jainendra),English (Pradhyuman),Business (Pradhyuman),Hindi (Jainendra),Hindi (Jainendra)
+                Class 12 Arts,Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),Hindi (Jainendra),English (Pradhyuman),English Literature (Harshita),Hindi (Jainendra),Hindi (Jainendra)
 
 		Thursday
 		Class,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM


### PR DESCRIPTION
## Summary
- align Class 12 Commerce's Wednesday schedule so English occurs in period 5 alongside the other Class 12 streams
- move Hindi for Class 12 Commerce to periods 4, 7, and 8 to match the other Class 12 schedules

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912c53474d8832ea15f3e23a08238ae)