### PR TITLE
Fix Combined English-Hindi Sessions in Timetable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1709,9 +1709,9 @@
 		Class 8,Hindi (Antima),Sanskrit (Antima),ELGA (Harshita),ELGA (Harshita),ELGA (Harshita),Maths (Leena),Science (Hemlata),SST (Harshita)
 		Class 9,Maths (Leena),English (Harshita),Hindi (Jainendra),CCS (Maya),Science (Toshit),Science (Toshit),Sanskrit (Antima),SST (Pradhyuman)
 		Class 10,SST (Pradhyuman),CCS (Maya),Maths (Nathulal),Sanskrit (Antima),Hindi (Antima),English (Harshita),Science (Toshit),Maths (Nathulal)
-		Class 11 Science,Physics (Phy),Physics (Phy),Chemistry (Toshit),Chemistry (Toshit),Biology (Hemlata),Hindi (Jainendra),English (Pradhyuman),Hindi (Jainendra)
-		Class 11 Commerce,Self Study (Maya),Business (Nidhika),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal),Hindi (Jainendra),English (Pradhyuman),Hindi (Jainendra)
-		Class 11 Arts,English Literature (Harshita),Political Science (Pradhyuman),Economics (Prakash),Geography (Prakash),CCS (Maya),Hindi (Jainendra),English (Pradhyuman),Hindi (Jainendra)
+		Class 11 Science,Physics (Phy),Physics (Phy),Chemistry (Toshit),Chemistry (Toshit),Hindi (Jainendra),Hindi (Jainendra),English (Pradhyuman),Hindi (Jainendra)
+		Class 11 Commerce,Self Study (Maya),Business (Nidhika),Economics (Prakash),Accountancy (Nathulal),Hindi (Jainendra),Hindi (Jainendra),English (Pradhyuman),Hindi (Jainendra)
+		Class 11 Arts,English Literature (Harshita),Political Science (Pradhyuman),Economics (Prakash),Geography (Prakash),Hindi (Jainendra),Hindi (Jainendra),English (Pradhyuman),Hindi (Jainendra)
 		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Biology (Hemlata),Biology (Hemlata),Hindi (Jainendra),English (Pradhyuman),Physics (Phy),Biology (Hemlata)
 		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),CCS (Maya),Business (Pradhyuman),Hindi (Jainendra),English (Pradhyuman),Accountancy (Nathulal),Sports (Rakesh)
 		Class 12 Arts,Geography (Prakash),Geography (Prakash),Political Science (Pradhyuman),Hindi (Jainendra),Hindi (Jainendra),English (Pradhyuman),English Literature (Harshita),Sports (Rakesh)
@@ -1728,9 +1728,9 @@
 		Class 8,Sanskrit (Antima),Science (Hemlata),ELGA (Harshita),ELGA (Harshita),ELGA (Harshita),English Boards (Rashmita),SST (Harshita),Maths (Leena)
 		Class 9,Maths (Leena),Maths (Leena),Hindi (Jainendra),Science (Toshit),Sports (Rakesh),Sanskrit (Antima),SST (Pradhyuman),English (Harshita)
 		Class 10,SST (Pradhyuman),English (Harshita),Science (Toshit),Maths (Nathulal),Sanskrit (Antima),Science (Toshit),Hindi (Antima),Maths (Nathulal)
-		Class 11 Science,Physics (Phy),Physics (Phy),English (Pradhyuman),Biology (Hemlata),Biology (Hemlata),Sports (Rakesh),Chemistry (Toshit),Chemistry (Toshit)
-		Class 11 Commerce,CCS (Maya),Economics (Prakash),English (Pradhyuman),Self Study (Maya),Accountancy (Nathulal),Accountancy (Nathulal),Business (Nidhika),Sports (Rakesh)
-		Class 11 Arts,English Literature (Harshita),Economics (Prakash),English (Pradhyuman),Geography (Prakash),Self Study (Toshit),Political Science (Pradhyuman),Sports (Rakesh),Sports (Rakesh)
+		Class 11 Science,Physics (Phy),Physics (Phy),English (Pradhyuman),Biology (Hemlata),Biology (Hemlata),Sports (Rakesh),Hindi (Jainendra),Hindi (Jainendra)
+		Class 11 Commerce,CCS (Maya),Economics (Prakash),English (Pradhyuman),Self Study (Maya),Accountancy (Nathulal),Accountancy (Nathulal),Hindi (Jainendra),Hindi (Jainendra)
+		Class 11 Arts,English Literature (Harshita),Economics (Prakash),English (Pradhyuman),Geography (Prakash),Self Study (Toshit),Political Science (Pradhyuman),Hindi (Jainendra),Hindi (Jainendra)
                 Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Biology (Hemlata),Hindi (Jainendra),English (Pradhyuman),Sports (Rakesh),Hindi (Jainendra),Hindi (Jainendra)
                 Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),CCS (Maya),Hindi (Jainendra),English (Pradhyuman),Business (Pradhyuman),Hindi (Jainendra),Hindi (Jainendra)
                 Class 12 Arts,Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),Hindi (Jainendra),English (Pradhyuman),English Literature (Harshita),Hindi (Jainendra),Hindi (Jainendra)
@@ -1748,11 +1748,11 @@
 		Class 9,Maths (Leena),Hindi (Jainendra),SST (Pradhyuman),SST (Pradhyuman),Sanskrit (Antima),Sanskrit (Antima),Science (Toshit),Science (Toshit)
 		Class 10,SST (Pradhyuman),SST (Pradhyuman),Science (Toshit),Science (Toshit),Maths (Nathulal),Maths (Nathulal),English (Harshita),Sanskrit (Antima)
 		Class 11 Science,Physics (Phy),Physics (Phy),Biology (Hemlata),Biology (Hemlata),Chemistry (Toshit),Chemistry (Toshit),Hindi (Jainendra),English (Pradhyuman)
-		Class 11 Commerce,CCS (Maya),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal),Hindi (Jainendra),Business (Nidhika),Hindi (Jainendra),English (Pradhyuman)
+		Class 11 Commerce,CCS (Maya),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal),Business (Nidhika),Business (Nidhika),Hindi (Jainendra),English (Pradhyuman)
 		Class 11 Arts,English Literature (Harshita),Economics (Prakash),Geography (Prakash),Self Study (Antima),Political Science (Pradhyuman),Sports (Rakesh),Hindi (Jainendra),English (Pradhyuman)
 		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Hindi (Jainendra),Physics (Phy),Biology (Hemlata),Biology (Hemlata),English (Pradhyuman),Hindi (Jainendra)
 		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Hindi (Jainendra),Economics (Prakash),Sports (Rakesh),Business (Pradhyuman),English (Pradhyuman),Hindi (Jainendra)
-		Class 12 Arts,Geography (Prakash),Self Study (Antima),Hindi (Jainendra),Economics (Prakash),Sports (Rakesh),CCS (Maya),Hindi (Jainendra),Hindi (Jainendra)
+		Class 12 Arts,Geography (Prakash),Self Study (Antima),Hindi (Jainendra),Economics (Prakash),Sports (Rakesh),CCS (Maya),English (Pradhyuman),Hindi (Jainendra)
 
 		Friday
 		Class,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
@@ -1771,7 +1771,7 @@
 		Class 11 Arts,English Literature (Harshita),Economics (Prakash),Hindi (Jainendra),Geography (Prakash),Political Science (Pradhyuman),English (Pradhyuman),Sports (Rakesh),Sports (Rakesh)
 		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Physics (Phy),Physics (Phy),Sports (Rakesh),Biology (Hemlata),English (Pradhyuman),Hindi (Jainendra)
 		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),Business (Pradhyuman),Sports (Rakesh),Accountancy (Nathulal),English (Pradhyuman),Hindi (Jainendra)
-		Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics/Political Science (Prakash/Pradhyuman),English Literature (Harshita),Sports (Rakesh),Sports (Rakesh),Hindi (Jainendra),English (Pradhyuman)
+		Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics/Political Science (Prakash/Pradhyuman),English Literature (Harshita),Sports (Rakesh),Sports (Rakesh),English (Pradhyuman),Hindi (Jainendra)
 
 		Saturday
 		Class,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM


### PR DESCRIPTION
Synchronized English and Hindi teaching sessions for Class 11 and Class 12 (Science, Commerce, Arts) to enable combined teaching across streams.

Changes made:
- Tuesday: Aligned all Class 11 P5 to Hindi (Jainendra)
- Wednesday: Aligned all Class 11 P7-8 to Hindi (Jainendra)
- Thursday: Adjusted Class 11 Commerce P5 and Class 12 Arts P7
- Friday: Swapped Class 12 Arts P7-8 for better alignment

Total: 16 period changes across 4 days