### PR TITLE
feat: update inline timetable for 2026-27 (add Assembly slot) and bump SW cache to v5

### DIFF
--- a/index.html
+++ b/index.html
@@ -1679,115 +1679,115 @@
 
 		// --- ENHANCED DATA STORE ---
 		const rawData = `Monday
-		Class,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
-		Class 1,Maths (Bindu),Sports (Rakesh),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),EVS (Ravina),EVS (Ravina)
-		Class 2,Maths (Ravina),EVS (Bindu),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Bindu),Hindi (Bindu),CCS (Maya)
-		Class 3,EVS (Rashmita),EVS (Rashmita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Ravina),Hindi (Kusum),Hindi (Kusum)
-		Class 4,Hindi (Kusum),Hindi (Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Anita),EVS (Rashmita),EVS (Rashmita)
-		Class 5,Maths (Nidhika),Maths (Nidhika),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Kusum),CCS (Maya),EVS (Anita)
-		Class 6,English compulsory (Hemlata),CCS (Maya),Hindi (Jainendra),Sports (Rakesh),NoteBook Checking (Antima),SST (Rashmita),Maths (Nidhika),Maths (Nidhika)
-		Class 7,Maths (Anita),Maths (Anita),Sanskrit (Antima),Hindi (Jainendra),SST (Nidhika),English compulsory (Harshita),Sports (Rakesh),NoteBook Checking (Antima)
-		Class 8,Sanskrit (Antima),Hindi (Jainendra),English compulsory (Pradhyuman),SST (Harshita),SST (Harshita),CCS (Maya),Maths (Prakash),Maths (Prakash)
-		Class 9,Hindi (Jainendra),Sanskrit (Antima),Science (Toshit),Science (Toshit),SST (Pradhyuman),SST (Pradhyuman),English compulsory (Harshita),Maths (Nathulal)
-		Class 10,SST (Pradhyuman),English compulsory (Harshita),English compulsory (Harshita),Sanskrit (Antima),Maths (Nathulal),Hindi (Antima),Science (Toshit),Science (Toshit)
-		Class 11 Science,Physics (Mahesh),Biology (Hemlata),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),Chemistry (Toshit),Free,Free
-		Class 11 Commerce,Self Study (Maya),Economics (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika),Accountancy (Nathulal),Free
-		Class 11 Arts,English Literature (Harshita),Economics (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Geography (Prakash),NoteBook Checking (Antima),Political Science (Pradhyuman)
-		Class 12 Science,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),Biology (Hemlata),Biology (Hemlata),Hindi (Jainendra),English compulsory (Pradhyuman),Free
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Business Studies (Nidhika),Economics (Prakash),Sports (Rakesh),Hindi (Jainendra),English compulsory (Pradhyuman),Free
-		Class 12 Arts,Geography (Prakash),Political Science (Pradhyuman),Sports (Rakesh),Economics (Prakash),CCS (Maya),Hindi (Jainendra),English compulsory (Pradhyuman),English Literature (Harshita)
+		Class,Assembly<br>8:00 AM - 8:30 AM,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
+		Class 1,Assembly,Maths (Bindu),Sports (Rakesh),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),EVS (Ravina),EVS (Ravina)
+		Class 2,Assembly,Maths (Ravina),EVS (Bindu),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Bindu),Hindi (Bindu),CCS (Maya)
+		Class 3,Assembly,EVS (Rashmita),EVS (Rashmita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Ravina),Hindi (Kusum),Hindi (Kusum)
+		Class 4,Assembly,Hindi (Kusum),Hindi (Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Anita),EVS (Rashmita),EVS (Rashmita)
+		Class 5,Assembly,Maths (Nidhika),Maths (Nidhika),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Kusum),CCS (Maya),EVS (Anita)
+		Class 6,Assembly,English compulsory (Hemlata),CCS (Maya),Hindi (Jainendra),Sports (Rakesh),NoteBook Checking (Antima),SST (Rashmita),Maths (Nidhika),Maths (Nidhika)
+		Class 7,Assembly,Maths (Anita),Maths (Anita),Sanskrit (Antima),Hindi (Jainendra),SST (Nidhika),English compulsory (Harshita),Sports (Rakesh),NoteBook Checking (Antima)
+		Class 8,Assembly,Sanskrit (Antima),Hindi (Jainendra),English compulsory (Pradhyuman),SST (Harshita),SST (Harshita),CCS (Maya),Maths (Prakash),Maths (Prakash)
+		Class 9,Assembly,Hindi (Jainendra),Sanskrit (Antima),Science (Toshit),Science (Toshit),SST (Pradhyuman),SST (Pradhyuman),English compulsory (Harshita),Maths (Nathulal)
+		Class 10,Assembly,SST (Pradhyuman),English compulsory (Harshita),English compulsory (Harshita),Sanskrit (Antima),Maths (Nathulal),Hindi (Antima),Science (Toshit),Science (Toshit)
+		Class 11 Science,Assembly,Physics (Mahesh),Biology (Hemlata),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),Chemistry (Toshit),Free,Free
+		Class 11 Commerce,Assembly,Self Study (Maya),Economics (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika),Accountancy (Nathulal),Free
+		Class 11 Arts,Assembly,English Literature (Harshita),Economics (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Geography (Prakash),NoteBook Checking (Antima),Political Science (Pradhyuman)
+		Class 12 Science,Assembly,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),Biology (Hemlata),Biology (Hemlata),Hindi (Jainendra),English compulsory (Pradhyuman),Free
+		Class 12 Commerce,Assembly,Accountancy (Nathulal),Accountancy (Nathulal),Business Studies (Nidhika),Economics (Prakash),Sports (Rakesh),Hindi (Jainendra),English compulsory (Pradhyuman),Free
+		Class 12 Arts,Assembly,Geography (Prakash),Political Science (Pradhyuman),Sports (Rakesh),Economics (Prakash),CCS (Maya),Hindi (Jainendra),English compulsory (Pradhyuman),English Literature (Harshita)
 
 		Tuesday
-		Class,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
-		Class 1,Maths (Bindu),Maths (Bindu),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),Hindi (Anjana),EVS (Ravina)
-		Class 2,Maths (Ravina),Maths (Ravina),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Bindu),EVS (Bindu),EVS (Bindu)
-		Class 3,EVS (Rashmita),Hindi (Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Ravina),Maths (Ravina),Sports (Rakesh)
-		Class 4,Hindi (Kusum),Sports (Rakesh),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Rashmita),Maths (Anita),Maths (Anita)
-		Class 5,Maths (Nidhika),Maths (Nidhika),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Anita),Hindi (Kusum),Hindi (Kusum)
-		Class 6,English compulsory (Hemlata),Chemistry (Hemlata),Physics (Hemlata),Sanskrit (Jainendra),Sports (Rakesh),Maths (Nidhika),Maths (Nidhika),SST (Rashmita)
-		Class 7,Maths (Anita),Maths (Anita),Sanskrit (Antima),Physics (Toshit),SST (Nidhika),Biology (Hemlata),CCS (Maya),English compulsory (Harshita)
-		Class 8,Sanskrit (Antima),Hindi (Jainendra),Maths (Prakash),Maths (Prakash),English compulsory (Pradhyuman),SST (Harshita),Chemistry (Toshit),Biology (Hemlata)
-		Class 9,Hindi (Jainendra),CCS (Maya),Maths (Nathulal),Sanskrit (Antima),English compulsory (Harshita),NoteBook Checking (Antima),SST (Pradhyuman),Science (Toshit)
-		Class 10,SST (Pradhyuman),SST (Pradhyuman),Science (Toshit),English compulsory (Harshita),Sanskrit (Antima),Maths (Nathulal),Maths (Nathulal),Hindi (Antima)
-		Class 11 Science,Physics (Mahesh),Physics (Mahesh),Sports (Rakesh),Biology (Hemlata),Biology (Hemlata),Chemistry (Toshit),Hindi (Jainendra),English compulsory (Pradhyuman)
-		Class 11 Commerce,CCS (Maya),NoteBook Checking (Antima),Business Studies (Nidhika),Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),Hindi (Jainendra),English compulsory (Pradhyuman)
-		Class 11 Arts,English Literature (Harshita),Geography (Prakash),English Literature (Harshita),Political Science (Pradhyuman),Geography (Prakash),Economics (Prakash),Hindi (Jainendra),English compulsory (Pradhyuman)
-		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Physics (Mahesh),Sports (Rakesh),Hindi (Jainendra),English compulsory (Pradhyuman),Biology (Hemlata),Free
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),CCS (Maya),Business Studies (Nidhika),Hindi (Jainendra),English compulsory (Pradhyuman),Sports (Rakesh),Economics (Prakash)
-		Class 12 Arts,Geography (Prakash),English Literature (Harshita),Political Science (Pradhyuman),CCS (Maya),Hindi (Jainendra),English compulsory (Pradhyuman),English Literature (Harshita),Economics (Prakash)
+		Class,Assembly<br>8:00 AM - 8:30 AM,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
+		Class 1,Assembly,Maths (Bindu),Maths (Bindu),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),Hindi (Anjana),EVS (Ravina)
+		Class 2,Assembly,Maths (Ravina),Maths (Ravina),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Bindu),EVS (Bindu),EVS (Bindu)
+		Class 3,Assembly,EVS (Rashmita),Hindi (Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Ravina),Maths (Ravina),Sports (Rakesh)
+		Class 4,Assembly,Hindi (Kusum),Sports (Rakesh),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Rashmita),Maths (Anita),Maths (Anita)
+		Class 5,Assembly,Maths (Nidhika),Maths (Nidhika),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Anita),Hindi (Kusum),Hindi (Kusum)
+		Class 6,Assembly,English compulsory (Hemlata),Chemistry (Hemlata),Physics (Hemlata),Sanskrit (Jainendra),Sports (Rakesh),Maths (Nidhika),Maths (Nidhika),SST (Rashmita)
+		Class 7,Assembly,Maths (Anita),Maths (Anita),Sanskrit (Antima),Physics (Toshit),SST (Nidhika),Biology (Hemlata),CCS (Maya),English compulsory (Harshita)
+		Class 8,Assembly,Sanskrit (Antima),Hindi (Jainendra),Maths (Prakash),Maths (Prakash),English compulsory (Pradhyuman),SST (Harshita),Chemistry (Toshit),Biology (Hemlata)
+		Class 9,Assembly,Hindi (Jainendra),CCS (Maya),Maths (Nathulal),Sanskrit (Antima),English compulsory (Harshita),NoteBook Checking (Antima),SST (Pradhyuman),Science (Toshit)
+		Class 10,Assembly,SST (Pradhyuman),SST (Pradhyuman),Science (Toshit),English compulsory (Harshita),Sanskrit (Antima),Maths (Nathulal),Maths (Nathulal),Hindi (Antima)
+		Class 11 Science,Assembly,Physics (Mahesh),Physics (Mahesh),Sports (Rakesh),Biology (Hemlata),Biology (Hemlata),Chemistry (Toshit),Hindi (Jainendra),English compulsory (Pradhyuman)
+		Class 11 Commerce,Assembly,CCS (Maya),NoteBook Checking (Antima),Business Studies (Nidhika),Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),Hindi (Jainendra),English compulsory (Pradhyuman)
+		Class 11 Arts,Assembly,English Literature (Harshita),Geography (Prakash),English Literature (Harshita),Political Science (Pradhyuman),Geography (Prakash),Economics (Prakash),Hindi (Jainendra),English compulsory (Pradhyuman)
+		Class 12 Science,Assembly,Chemistry (Toshit),Chemistry (Toshit),Physics (Mahesh),Sports (Rakesh),Hindi (Jainendra),English compulsory (Pradhyuman),Biology (Hemlata),Free
+		Class 12 Commerce,Assembly,Accountancy (Nathulal),Accountancy (Nathulal),CCS (Maya),Business Studies (Nidhika),Hindi (Jainendra),English compulsory (Pradhyuman),Sports (Rakesh),Economics (Prakash)
+		Class 12 Arts,Assembly,Geography (Prakash),English Literature (Harshita),Political Science (Pradhyuman),CCS (Maya),Hindi (Jainendra),English compulsory (Pradhyuman),English Literature (Harshita),Economics (Prakash)
 
 
-		Class 1,Maths (Bindu),EVS (Ravina),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),Hindi (Anjana),NoteBook Checking (Antima)
-		Class 2,Maths (Ravina),Sports (Rakesh),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Bindu),EVS (Bindu),Hindi (Bindu)
-		Class 3,EVS (Rashmita),EVS (Rashmita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Kusum),Maths (Ravina),Maths (Ravina)
-		Class 4,Hindi (Kusum),Hindi (Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Anita),Maths (Anita),EVS (Rashmita)
-		Class 5,Maths (Nidhika),EVS (Anita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Robotics (Maya),CCS (Maya),Hindi (Kusum)
-		Class 6,Biology (Hemlata),Sanskrit (Jainendra),Chemistry (Hemlata),Maths (Nidhika),Maths (Nidhika),English compulsory (Hemlata),SST (Rashmita),Hindi (Jainendra)
-		Class 7,Maths (Anita),English compulsory (Harshita),Sports (Rakesh),Physics (Toshit),Hindi (Jainendra),Sanskrit (Antima),SST (Nidhika),Robotics (Maya)
-		Class 8,Sanskrit (Antima),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),Chemistry (Toshit),Maths (Prakash),SST (Harshita),Physics (Toshit)
-		Class 9,Hindi (Jainendra),Sanskrit (Antima),English compulsory (Harshita),English compulsory (Harshita),Maths (Nathulal),Science (Toshit),Sports (Rakesh),SST (Pradhyuman)
-		Class 10,SST (Pradhyuman),CCS (Maya),Sanskrit (Antima),Hindi (Antima),English compulsory (Harshita),English compulsory (Harshita),Science (Toshit),Maths (Nathulal)
-		Class 11 Science,Physics (Mahesh),Physics (Mahesh),Chemistry (Toshit),Sports (Rakesh),English compulsory (Pradhyuman),Hindi (Jainendra),Biology (Hemlata),Biology (Hemlata)
-		Class 11 Commerce,Self Study (Maya),Business Studies (Nidhika),Accountancy (Nathulal),Accountancy (Nathulal),English compulsory (Pradhyuman),Hindi (Jainendra),Economics (Prakash),Free
-		Class 11 Arts,English Literature (Harshita),Geography (Prakash),CCS (Maya),Political Science (Pradhyuman),English compulsory (Pradhyuman),Hindi (Jainendra),Economics (Prakash),Geography (Prakash)
-		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Physics (Mahesh),Biology (Hemlata),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),Free
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),CCS (Maya),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika)
-		Class 12 Arts,Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),Geography (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),English Literature (Harshita)
+		Class 1,Assembly,Maths (Bindu),EVS (Ravina),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),Hindi (Anjana),NoteBook Checking (Antima)
+		Class 2,Assembly,Maths (Ravina),Sports (Rakesh),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Bindu),EVS (Bindu),Hindi (Bindu)
+		Class 3,Assembly,EVS (Rashmita),EVS (Rashmita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Kusum),Maths (Ravina),Maths (Ravina)
+		Class 4,Assembly,Hindi (Kusum),Hindi (Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Anita),Maths (Anita),EVS (Rashmita)
+		Class 5,Assembly,Maths (Nidhika),EVS (Anita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Robotics (Maya),CCS (Maya),Hindi (Kusum)
+		Class 6,Assembly,Biology (Hemlata),Sanskrit (Jainendra),Chemistry (Hemlata),Maths (Nidhika),Maths (Nidhika),English compulsory (Hemlata),SST (Rashmita),Hindi (Jainendra)
+		Class 7,Assembly,Maths (Anita),English compulsory (Harshita),Sports (Rakesh),Physics (Toshit),Hindi (Jainendra),Sanskrit (Antima),SST (Nidhika),Robotics (Maya)
+		Class 8,Assembly,Sanskrit (Antima),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),Chemistry (Toshit),Maths (Prakash),SST (Harshita),Physics (Toshit)
+		Class 9,Assembly,Hindi (Jainendra),Sanskrit (Antima),English compulsory (Harshita),English compulsory (Harshita),Maths (Nathulal),Science (Toshit),Sports (Rakesh),SST (Pradhyuman)
+		Class 10,Assembly,SST (Pradhyuman),CCS (Maya),Sanskrit (Antima),Hindi (Antima),English compulsory (Harshita),English compulsory (Harshita),Science (Toshit),Maths (Nathulal)
+		Class 11 Science,Assembly,Physics (Mahesh),Physics (Mahesh),Chemistry (Toshit),Sports (Rakesh),English compulsory (Pradhyuman),Hindi (Jainendra),Biology (Hemlata),Biology (Hemlata)
+		Class 11 Commerce,Assembly,Self Study (Maya),Business Studies (Nidhika),Accountancy (Nathulal),Accountancy (Nathulal),English compulsory (Pradhyuman),Hindi (Jainendra),Economics (Prakash),Free
+		Class 11 Arts,Assembly,English Literature (Harshita),Geography (Prakash),CCS (Maya),Political Science (Pradhyuman),English compulsory (Pradhyuman),Hindi (Jainendra),Economics (Prakash),Geography (Prakash)
+		Class 12 Science,Assembly,Chemistry (Toshit),Chemistry (Toshit),Physics (Mahesh),Biology (Hemlata),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),Free
+		Class 12 Commerce,Assembly,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),CCS (Maya),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika)
+		Class 12 Arts,Assembly,Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),Geography (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),English Literature (Harshita)
 
 
-		Class 1,Maths (Bindu),Maths (Bindu),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),EVS (Ravina),EVS (Ravina)
-		Class 2,Maths (Ravina),Maths (Ravina),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Bindu),Hindi (Bindu),Hindi (Bindu)
-		Class 3,EVS (Rashmita),CCS (Maya),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Ravina),Hindi (Kusum),Hindi (Kusum)
-		Class 4,Hindi (Kusum),Maths (Anita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),CCS (Maya),EVS (Rashmita),EVS (Rashmita)
-		Class 5,Maths (Nidhika),Maths (Nidhika),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Kusum),EVS (Anita),EVS (Anita)
-		Class 6,English compulsory (Hemlata),SST (Rashmita),Maths (Nidhika),CCS (Maya),Hindi (Jainendra),Chemistry (Hemlata),Biology (Hemlata),Robotics (Maya)
-		Class 7,Maths (Anita),Hindi (Jainendra),Physics (Toshit),SST (Nidhika),Biology (Hemlata),Sanskrit (Antima),English compulsory (Harshita),Chemistry (Hemlata)
-		Class 8,NoteBook Checking (Antima),Biology (Hemlata),CCS (Maya),English compulsory (Pradhyuman),Sports (Rakesh),SST (Harshita),Maths (Prakash),Maths (Prakash)
-		Class 9,Hindi (Jainendra),Sanskrit (Antima),SST (Pradhyuman),English compulsory (Harshita),English compulsory (Harshita),Science (Toshit),Maths (Nathulal),Maths (Nathulal)
-		Class 10,SST (Pradhyuman),SST (Pradhyuman),English compulsory (Harshita),Hindi (Antima),Sanskrit (Antima),Maths (Nathulal),Sports (Rakesh),Science (Toshit)
-		Class 11 Science,Physics (Mahesh),Physics (Mahesh),Biology (Hemlata),Chemistry (Toshit),Chemistry (Toshit),English compulsory (Pradhyuman),Hindi (Jainendra),Free
-		Class 11 Commerce,CCS (Maya),Sports (Rakesh),Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika)
-		Class 11 Arts,English Literature (Harshita),English Literature (Harshita),Geography (Prakash),Sports (Rakesh),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Political Science (Pradhyuman)
-		Class 12 Science,Chemistry (Toshit),Chemistry (Toshit),Physics (Mahesh),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),NoteBook Checking (Antima),Free
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),NoteBook Checking (Antima),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika),Free
-		Class 12 Arts,Geography (Prakash),Geography (Prakash),Sports (Rakesh),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Political Science (Pradhyuman),English Literature (Harshita)
+		Class 1,Assembly,Maths (Bindu),Maths (Bindu),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Anjana),EVS (Ravina),EVS (Ravina)
+		Class 2,Assembly,Maths (Ravina),Maths (Ravina),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),EVS (Bindu),Hindi (Bindu),Hindi (Bindu)
+		Class 3,Assembly,EVS (Rashmita),CCS (Maya),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Maths (Ravina),Hindi (Kusum),Hindi (Kusum)
+		Class 4,Assembly,Hindi (Kusum),Maths (Anita),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),CCS (Maya),EVS (Rashmita),EVS (Rashmita)
+		Class 5,Assembly,Maths (Nidhika),Maths (Nidhika),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),ELGA (Bindu, Anita, Rashmita, Kusum),Hindi (Kusum),EVS (Anita),EVS (Anita)
+		Class 6,Assembly,English compulsory (Hemlata),SST (Rashmita),Maths (Nidhika),CCS (Maya),Hindi (Jainendra),Chemistry (Hemlata),Biology (Hemlata),Robotics (Maya)
+		Class 7,Assembly,Maths (Anita),Hindi (Jainendra),Physics (Toshit),SST (Nidhika),Biology (Hemlata),Sanskrit (Antima),English compulsory (Harshita),Chemistry (Hemlata)
+		Class 8,Assembly,NoteBook Checking (Antima),Biology (Hemlata),CCS (Maya),English compulsory (Pradhyuman),Sports (Rakesh),SST (Harshita),Maths (Prakash),Maths (Prakash)
+		Class 9,Assembly,Hindi (Jainendra),Sanskrit (Antima),SST (Pradhyuman),English compulsory (Harshita),English compulsory (Harshita),Science (Toshit),Maths (Nathulal),Maths (Nathulal)
+		Class 10,Assembly,SST (Pradhyuman),SST (Pradhyuman),English compulsory (Harshita),Hindi (Antima),Sanskrit (Antima),Maths (Nathulal),Sports (Rakesh),Science (Toshit)
+		Class 11 Science,Assembly,Physics (Mahesh),Physics (Mahesh),Biology (Hemlata),Chemistry (Toshit),Chemistry (Toshit),English compulsory (Pradhyuman),Hindi (Jainendra),Free
+		Class 11 Commerce,Assembly,CCS (Maya),Sports (Rakesh),Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika)
+		Class 11 Arts,Assembly,English Literature (Harshita),English Literature (Harshita),Geography (Prakash),Sports (Rakesh),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Political Science (Pradhyuman)
+		Class 12 Science,Assembly,Chemistry (Toshit),Chemistry (Toshit),Physics (Mahesh),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra),NoteBook Checking (Antima),Free
+		Class 12 Commerce,Assembly,Accountancy (Nathulal),Accountancy (Nathulal),NoteBook Checking (Antima),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika),Free
+		Class 12 Arts,Assembly,Geography (Prakash),Geography (Prakash),Sports (Rakesh),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Political Science (Pradhyuman),English Literature (Harshita)
 
 
-		Class 1,Maths (Bindu),Maths (Bindu),EVS (Ravina),EVS (Ravina),Sports (Rakesh),CCS (Maya),Hindi (Anjana),Hindi (Anjana)
-		Class 2,Maths (Ravina),Maths (Ravina),EVS (Bindu),EVS (Bindu),CCS (Maya),Hindi (Bindu),Hindi (Bindu),Sports (Rakesh)
-		Class 3,EVS (Rashmita),EVS (Rashmita),NoteBook Checking (Antima),CCS (Maya),Maths (Ravina),Maths (Ravina),Hindi (Kusum),Hindi (Kusum)
-		Class 4,Hindi (Kusum),Hindi (Kusum),EVS (Rashmita),EVS (Rashmita),Maths (Anita),Maths (Anita),Robotics (Maya),NoteBook Checking (Antima)
-		Class 5,Maths (Nidhika),EVS (Anita),EVS (Anita),NoteBook Checking (Antima),Hindi (Kusum),Hindi (Kusum),Sports (Rakesh),English compulsory (Ravina)
-		Class 6,Physics (Hemlata),Sanskrit (Jainendra),English compulsory (Hemlata),Hindi (Jainendra),SST (Rashmita),SST (Rashmita),Biology (Hemlata),Maths (Nidhika)
-		Class 7,Maths (Anita),CCS (Maya),SST (Nidhika),SST (Nidhika),Chemistry (Hemlata),English compulsory (Harshita),Hindi (Jainendra),Biology (Hemlata)
-		Class 8,Sanskrit (Antima),Sports (Rakesh),English compulsory (Pradhyuman),Physics (Toshit),SST (Harshita),Hindi (Jainendra),Maths (Prakash),Robotics (Maya)
-		Class 9,Hindi (Jainendra),Science (Toshit),Sports (Rakesh),English compulsory (Harshita),Sanskrit (Antima),Maths (Nathulal),SST (Pradhyuman),SST (Pradhyuman)
-		Class 10,SST (Pradhyuman),Sanskrit (Antima),English compulsory (Harshita),Maths (Nathulal),Maths (Nathulal),Hindi (Antima),Science (Toshit),Science (Toshit)
-		Class 11 Science,Physics (Mahesh),English compulsory (Pradhyuman),Hindi (Jainendra),Biology (Hemlata),Chemistry (Toshit),Chemistry (Toshit),Free,Free
-		Class 11 Commerce,Self Study (Maya),English compulsory (Pradhyuman),Hindi (Jainendra),Sports (Rakesh),Business Studies (Nidhika),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal)
-		Class 11 Arts,English Literature (Harshita),English compulsory (Pradhyuman),Hindi (Jainendra),Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),English Literature (Harshita),Geography (Prakash)
-		Class 12 Science,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),English compulsory (Pradhyuman),Hindi (Jainendra),Biology (Hemlata),Free,Free
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika),Business Studies (Nidhika),Free
-		Class 12 Arts,Geography (Prakash),Geography (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Political Science (Pradhyuman),NoteBook Checking (Antima),English Literature (Harshita)
+		Class 1,Assembly,Maths (Bindu),Maths (Bindu),EVS (Ravina),EVS (Ravina),Sports (Rakesh),CCS (Maya),Hindi (Anjana),Hindi (Anjana)
+		Class 2,Assembly,Maths (Ravina),Maths (Ravina),EVS (Bindu),EVS (Bindu),CCS (Maya),Hindi (Bindu),Hindi (Bindu),Sports (Rakesh)
+		Class 3,Assembly,EVS (Rashmita),EVS (Rashmita),NoteBook Checking (Antima),CCS (Maya),Maths (Ravina),Maths (Ravina),Hindi (Kusum),Hindi (Kusum)
+		Class 4,Assembly,Hindi (Kusum),Hindi (Kusum),EVS (Rashmita),EVS (Rashmita),Maths (Anita),Maths (Anita),Robotics (Maya),NoteBook Checking (Antima)
+		Class 5,Assembly,Maths (Nidhika),EVS (Anita),EVS (Anita),NoteBook Checking (Antima),Hindi (Kusum),Hindi (Kusum),Sports (Rakesh),English compulsory (Ravina)
+		Class 6,Assembly,Physics (Hemlata),Sanskrit (Jainendra),English compulsory (Hemlata),Hindi (Jainendra),SST (Rashmita),SST (Rashmita),Biology (Hemlata),Maths (Nidhika)
+		Class 7,Assembly,Maths (Anita),CCS (Maya),SST (Nidhika),SST (Nidhika),Chemistry (Hemlata),English compulsory (Harshita),Hindi (Jainendra),Biology (Hemlata)
+		Class 8,Assembly,Sanskrit (Antima),Sports (Rakesh),English compulsory (Pradhyuman),Physics (Toshit),SST (Harshita),Hindi (Jainendra),Maths (Prakash),Robotics (Maya)
+		Class 9,Assembly,Hindi (Jainendra),Science (Toshit),Sports (Rakesh),English compulsory (Harshita),Sanskrit (Antima),Maths (Nathulal),SST (Pradhyuman),SST (Pradhyuman)
+		Class 10,Assembly,SST (Pradhyuman),Sanskrit (Antima),English compulsory (Harshita),Maths (Nathulal),Maths (Nathulal),Hindi (Antima),Science (Toshit),Science (Toshit)
+		Class 11 Science,Assembly,Physics (Mahesh),English compulsory (Pradhyuman),Hindi (Jainendra),Biology (Hemlata),Chemistry (Toshit),Chemistry (Toshit),Free,Free
+		Class 11 Commerce,Assembly,Self Study (Maya),English compulsory (Pradhyuman),Hindi (Jainendra),Sports (Rakesh),Business Studies (Nidhika),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal)
+		Class 11 Arts,Assembly,English Literature (Harshita),English compulsory (Pradhyuman),Hindi (Jainendra),Geography (Prakash),Political Science (Pradhyuman),Economics (Prakash),English Literature (Harshita),Geography (Prakash)
+		Class 12 Science,Assembly,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),English compulsory (Pradhyuman),Hindi (Jainendra),Biology (Hemlata),Free,Free
+		Class 12 Commerce,Assembly,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Business Studies (Nidhika),Business Studies (Nidhika),Free
+		Class 12 Arts,Assembly,Geography (Prakash),Geography (Prakash),Economics (Prakash),English compulsory (Pradhyuman),Hindi (Jainendra),Political Science (Pradhyuman),NoteBook Checking (Antima),English Literature (Harshita)
 
 		Saturday
-		Class,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
-		Class 1,Maths (Bindu),Maths (Bindu),EVS (Ravina),EVS (Ravina),CCS (Maya),Hindi (Anjana),Hindi (Anjana),Robotics (Maya)
-		Class 2,Maths (Ravina),Maths (Ravina),NoteBook Checking (Antima),Robotics (Maya),Hindi (Bindu),Hindi (Bindu),EVS (Bindu),EVS (Bindu)
-		Class 3,EVS (Rashmita),EVS (Rashmita),Hindi (Kusum),Hindi (Kusum),Maths (Ravina),Maths (Ravina),Robotics (Maya),Sports (Rakesh)
-		Class 4,Hindi (Kusum),Hindi (Kusum),EVS (Rashmita),EVS (Rashmita),Sports (Rakesh),CCS (Maya),Maths (Anita),Maths (Anita)
-		Class 5,Maths (Nidhika),Maths (Nidhika),Sports (Rakesh),EVS (Anita),EVS (Anita),Hindi (Kusum),Hindi (Kusum),English compulsory (Ravina)
-		Class 6,English compulsory (Hemlata),English compulsory (Hemlata),Maths (Nidhika),Sanskrit (Jainendra),SST (Rashmita),SST (Rashmita),Hindi (Jainendra),Physics (Hemlata)
-		Class 7,Maths (Anita),Maths (Anita),Chemistry (Hemlata),Sanskrit (Antima),English compulsory (Harshita),Hindi (Jainendra),SST (Nidhika),SST (Nidhika)
-		Class 8,Sanskrit (Antima),Physics (Toshit),SST (Harshita),SST (Harshita),Hindi (Jainendra),English compulsory (Pradhyuman),Maths (Prakash),Chemistry (Toshit)
-		Class 9,Hindi (Jainendra),SST (Pradhyuman),Science (Toshit),Science (Toshit),Maths (Nathulal),Maths (Nathulal),Sanskrit (Antima),English compulsory (Harshita)
-		Class 10,SST (Pradhyuman),CCS (Maya),Maths (Nathulal),Maths (Nathulal),Science (Toshit),Sanskrit (Antima),English compulsory (Harshita),Hindi (Antima)
-		Class 11 Science,Physics (Mahesh),Hindi (Jainendra),English compulsory (Pradhyuman),Biology (Hemlata),NoteBook Checking (Antima),Chemistry (Toshit),Chemistry (Toshit),Free
-		Class 11 Commerce,Self Study (Maya),Hindi (Jainendra),English compulsory (Pradhyuman),Business Studies (Nidhika),Economics (Prakash),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal)
-		Class 11 Arts,English Literature (Harshita),Hindi (Jainendra),English compulsory (Pradhyuman),Political Science (Pradhyuman),Economics (Prakash),Economics (Prakash),Sports (Rakesh),Geography (Prakash)
-		Class 12 Science,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),Sports (Rakesh),Biology (Hemlata),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra)
-		Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),Economics (Prakash),Business Studies (Nidhika),Business Studies (Nidhika),English compulsory (Pradhyuman),Hindi (Jainendra)
-		Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Prakash),Economics (Prakash),Political Science (Pradhyuman),English Literature (Harshita),English compulsory (Pradhyuman),Hindi (Jainendra)`;
+		Class,Assembly<br>8:00 AM - 8:30 AM,Period 1<br>8:30 AM - 9:10 AM,Period 2<br>9:10 AM - 9:50 AM,Period 3<br>9:50 AM - 10:30 AM,Period 4<br>10:30 AM - 11:10 AM,Period 5<br>11:30 AM - 12:10 PM,Period 6<br>12:10 PM - 12:50 PM,Period 7<br>12:50 PM - 01:30 PM,Period 8<br>01:30 PM - 02:10 PM
+		Class 1,Assembly,Maths (Bindu),Maths (Bindu),EVS (Ravina),EVS (Ravina),CCS (Maya),Hindi (Anjana),Hindi (Anjana),Robotics (Maya)
+		Class 2,Assembly,Maths (Ravina),Maths (Ravina),NoteBook Checking (Antima),Robotics (Maya),Hindi (Bindu),Hindi (Bindu),EVS (Bindu),EVS (Bindu)
+		Class 3,Assembly,EVS (Rashmita),EVS (Rashmita),Hindi (Kusum),Hindi (Kusum),Maths (Ravina),Maths (Ravina),Robotics (Maya),Sports (Rakesh)
+		Class 4,Assembly,Hindi (Kusum),Hindi (Kusum),EVS (Rashmita),EVS (Rashmita),Sports (Rakesh),CCS (Maya),Maths (Anita),Maths (Anita)
+		Class 5,Assembly,Maths (Nidhika),Maths (Nidhika),Sports (Rakesh),EVS (Anita),EVS (Anita),Hindi (Kusum),Hindi (Kusum),English compulsory (Ravina)
+		Class 6,Assembly,English compulsory (Hemlata),English compulsory (Hemlata),Maths (Nidhika),Sanskrit (Jainendra),SST (Rashmita),SST (Rashmita),Hindi (Jainendra),Physics (Hemlata)
+		Class 7,Assembly,Maths (Anita),Maths (Anita),Chemistry (Hemlata),Sanskrit (Antima),English compulsory (Harshita),Hindi (Jainendra),SST (Nidhika),SST (Nidhika)
+		Class 8,Assembly,Sanskrit (Antima),Physics (Toshit),SST (Harshita),SST (Harshita),Hindi (Jainendra),English compulsory (Pradhyuman),Maths (Prakash),Chemistry (Toshit)
+		Class 9,Assembly,Hindi (Jainendra),SST (Pradhyuman),Science (Toshit),Science (Toshit),Maths (Nathulal),Maths (Nathulal),Sanskrit (Antima),English compulsory (Harshita)
+		Class 10,Assembly,SST (Pradhyuman),CCS (Maya),Maths (Nathulal),Maths (Nathulal),Science (Toshit),Sanskrit (Antima),English compulsory (Harshita),Hindi (Antima)
+		Class 11 Science,Assembly,Physics (Mahesh),Hindi (Jainendra),English compulsory (Pradhyuman),Biology (Hemlata),NoteBook Checking (Antima),Chemistry (Toshit),Chemistry (Toshit),Free
+		Class 11 Commerce,Assembly,Self Study (Maya),Hindi (Jainendra),English compulsory (Pradhyuman),Business Studies (Nidhika),Economics (Prakash),Economics (Prakash),Accountancy (Nathulal),Accountancy (Nathulal)
+		Class 11 Arts,Assembly,English Literature (Harshita),Hindi (Jainendra),English compulsory (Pradhyuman),Political Science (Pradhyuman),Economics (Prakash),Economics (Prakash),Sports (Rakesh),Geography (Prakash)
+		Class 12 Science,Assembly,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),Sports (Rakesh),Biology (Hemlata),Biology (Hemlata),English compulsory (Pradhyuman),Hindi (Jainendra)
+		Class 12 Commerce,Assembly,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),Economics (Prakash),Business Studies (Nidhika),Business Studies (Nidhika),English compulsory (Pradhyuman),Hindi (Jainendra)
+		Class 12 Arts,Assembly,Geography (Prakash),English Literature (Harshita),Economics (Prakash),Economics (Prakash),Political Science (Pradhyuman),English Literature (Harshita),English compulsory (Pradhyuman),Hindi (Jainendra)`;
 
 		// --- ENHANCED GLOBAL STATE ---
 		let state = {

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // Service Worker for Veer Patta Public School Timetable
 // Provides offline-first caching for the page shell and timetable data
 
-const CACHE_NAME = 'vpps-timetable-v4';
-const STATIC_CACHE_NAME = 'vpps-static-v4';
+const CACHE_NAME = 'vpps-timetable-v5';
+const STATIC_CACHE_NAME = 'vpps-static-v5';
 
 // Resources to cache on install
 const STATIC_ASSETS = [


### PR DESCRIPTION
### Motivation
- The repository needed to be updated to use the newly provided 2026–27 timetable PDFs while preserving the app's existing parsing and views.
- The change introduces an `Assembly` slot at the start of each day to reflect the new schedule shape from the provided data.
- The service worker cache must be versioned so clients receive the updated inline data immediately.

### Description
- Replaced the inline `rawData` block in `index.html` with the 2026–27 dataset and added an `Assembly<br>8:00 AM - 8:30 AM` header as the first column for every day, and prepended `Assembly` to each class row so rows align with the new header.
- Preserved the existing `Subject (Teacher)` cell format and parsing logic so day/class/teacher views and existing features continue to work unchanged.
- Bumped service worker constants in `sw.js` from `vpps-timetable-v4`/`vpps-static-v4` to `vpps-timetable-v5`/`vpps-static-v5` so clients will fetch the updated assets.
- No feature flags or UI/behavior changes were made outside of the data shape and SW versioning.

### Testing
- Ran `node tests/manual/test-mapping.js` and it passed (26 passed, 0 failed).
- Ran `node build-report.js` and the build report was generated successfully with the bundle remaining within the project's size budget.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf7737822c832db4ba8bbfe3410598)