### PR TITLE
fix: split ELGA teacher names instead of grouping as one

### DIFF
--- a/index.html
+++ b/index.html
@@ -2222,6 +2222,36 @@
 		}
 
 		// --- ENHANCED DATA PARSING ---
+		const splitTeacherNames = (teacherField, subjectField = '') => {
+			if (!teacherField || typeof teacherField !== 'string') return [];
+
+			const cleanedTeacherField = teacherField
+				.replace(/^\s*-\s*/, '')
+				.replace(/\s+/g, ' ')
+				.trim();
+			if (!cleanedTeacherField) return [];
+
+			// Common multi-teacher delimiters used in timetable cells
+			const explicitDelimiter = /[\/,&;+]|(?:\s+-\s+)/;
+			if (explicitDelimiter.test(cleanedTeacherField)) {
+				return cleanedTeacherField
+					.split(/[\/,&;+]|(?:\s+-\s+)/)
+					.map(name => name.trim())
+					.filter(Boolean);
+			}
+
+			// ELGA periods often contain multiple teacher names separated only by spaces.
+			// Example: "ELGA (Bindu Anita Rashmita Kusum)"
+			if ((subjectField || '').trim().toUpperCase() === 'ELGA') {
+				return cleanedTeacherField
+					.split(/\s+/)
+					.map(name => name.trim())
+					.filter(Boolean);
+			}
+
+			return [cleanedTeacherField];
+		};
+
 		const parseTimetableData = () => {
 			const timetable = {};
 			const teacherDetails = {};
@@ -2372,7 +2402,7 @@
 
 								// Track teacher details for enhanced scheduling
 								if (entry.teacher) {
-									const teachersInCell = entry.teacher.split('/').map(t => t.trim());
+									const teachersInCell = splitTeacherNames(entry.teacher, entry.subject);
 									const subjectsInCell = entry.subject.split('/').map(s => s.trim());
 
 									teachersInCell.forEach((teacherName, teacherIndex) => {

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // Service Worker for Veer Patta Public School Timetable
 // Provides offline-first caching for the page shell and timetable data
 
-const CACHE_NAME = 'vpps-timetable-v7';
-const STATIC_CACHE_NAME = 'vpps-static-v7';
+const CACHE_NAME = 'vpps-timetable-v8';
+const STATIC_CACHE_NAME = 'vpps-static-v8';
 
 // Resources to cache on install
 const STATIC_ASSETS = [


### PR DESCRIPTION
### Motivation
- Timetable parsing treated multi-name ELGA cells like `ELGA (Bindu Anita Rashmita Kusum)` as a single teacher identifier, breaking the Teacher View and workload/statistics.
- Some timetable entries include a leading hyphen (`- Bindu ...`) or use mixed delimiters which the prior simplistic split logic didn't handle.
- The change ensures each named teacher is registered individually so scheduling, conflict detection and recommendations work correctly.
- Service Worker cache must be bumped so clients receive the parser fix immediately.

### Description
- Added a `splitTeacherNames(teacherField, subjectField)` helper in `index.html` that strips leading hyphens, normalizes whitespace, recognizes explicit delimiters (`/`, `,`, `&`, `+`, spaced `-`), and splits space-separated names for `ELGA` cells. 
- Updated the timetable parser in `index.html` to use `splitTeacherNames()` instead of a raw `split('/')`, so `teacherDetails` now receives individual teacher entries. 
- Bumped Service Worker cache names in `sw.js` from `v7` to `v8` so updated assets (including the parser) are picked up by clients. 
- Files changed: `index.html`, `sw.js`.

### Testing
- Ran `node tests/manual/test-mapping.js` and it completed with all tests passing (`26 passed, 0 failed`).
- Ran `node build-report.js` which completed successfully and saved `docs/reports/build-report.json` without budget issues. 
- Executed a targeted Node validation that asserts ELGA and hyphen-prefixed teacher strings split into individual names and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcc73f3028832d80905381b7eca073)