### PR TITLE
Fix indefinite loading spinner during app initialization

### DIFF
--- a/docs/reports/build-report.json
+++ b/docs/reports/build-report.json
@@ -1,11 +1,11 @@
 {
-  "timestamp": "2026-04-18T02:55:53.956Z",
+  "timestamp": "2026-04-29T15:25:52.955Z",
   "files": [
     {
       "file": "index.html",
-      "rawSize": 219240,
-      "gzippedSize": 46803,
-      "compression": "78.7%"
+      "rawSize": 208765,
+      "gzippedSize": 46197,
+      "compression": "77.9%"
     },
     {
       "file": "scripts/perf.js",
@@ -57,9 +57,9 @@
     },
     {
       "file": "sw.js",
-      "rawSize": 7466,
-      "gzippedSize": 2354,
-      "compression": "68.5%"
+      "rawSize": 7239,
+      "gzippedSize": 2336,
+      "compression": "67.7%"
     },
     {
       "file": "manifest.webmanifest",
@@ -69,7 +69,7 @@
     }
   ],
   "totals": {
-    "raw": 368779,
-    "gzipped": 81769
+    "raw": 358077,
+    "gzipped": 81145
   }
 }

--- a/index.html
+++ b/index.html
@@ -5525,6 +5525,9 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 				}
 
 				hideLoader(0);
+			} finally {
+				// Safety fallback: never leave the app in an indefinite loading state.
+				hideLoader(0);
 			}
 		}
 

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // Service Worker for Veer Patta Public School Timetable
 // Provides offline-first caching for the page shell and timetable data
 
-const CACHE_NAME = 'vpps-timetable-v30';
-const STATIC_CACHE_NAME = 'vpps-static-v30';
+const CACHE_NAME = 'vpps-timetable-v31';
+const STATIC_CACHE_NAME = 'vpps-static-v31';
 
 // Core resources required for offline shell
 const CORE_ASSETS = [


### PR DESCRIPTION
### Motivation
- The app could remain stuck showing the loading/buffering spinner when `init()` encountered an error or an interrupted render path, so the intent is to ensure the loader is always cleared and users see a usable fallback instead of indefinite buffering.

### Description
- Added a safety `finally` block in `init()` that calls `hideLoader(0)` to guarantee the loader is hidden regardless of success or error during initialization (keeps the existing error-path hide as well). 
- Bumped service worker cache names in `sw.js` from `v30` to `v31` (`CACHE_NAME` and `STATIC_CACHE_NAME`) so clients pick up the runtime fix. 
- Regenerated the build report file `docs/reports/build-report.json` to reflect the runtime changes.

### Testing
- Ran `node build-report.js` and the build report completed successfully. 
- Ran `node tests/manual/colors/verify-contrast.js` and all color contrast checks passed. 
- Ran `node tests/manual/test-mapping.js` and all mapping tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f222b5a4a08333a081b09953ef92e4)