### PR TITLE
Fix rawData template literal terminator and bump service worker cache versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,7 +422,7 @@ Class 11 Commerce,Core Revision (Maya),Hindi (Jainendra),English compulsory (Pra
 Class 12 Commerce,Accountancy (Nathulal),Accountancy (Nathulal),Economics (Prakash),Economics (Prakash),Business Studies (Nidhika),Business Studies (Nidhika)
 Class 12 Science,Chemistry (Toshit),Physics (Mahesh),Physics (Mahesh),Chemistry (Toshit),Biology (Hemlata),Biology (Hemlata)
 Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Prakash),Economics (Prakash),Political Science (Pradhyuman),English Literature (Harshita)
-`;`;
+`;
 
 		// --- ENHANCED GLOBAL STATE ---
 		let state = {

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // Service Worker for Veer Patta Public School Timetable
 // Provides offline-first caching for the page shell and timetable data
 
-const CACHE_NAME = 'vpps-timetable-v32';
-const STATIC_CACHE_NAME = 'vpps-static-v32';
+const CACHE_NAME = 'vpps-timetable-v33';
+const STATIC_CACHE_NAME = 'vpps-static-v33';
 
 // Core resources required for offline shell
 const CORE_ASSETS = [


### PR DESCRIPTION
### Motivation
- A stray extra sequence after the `rawData` template literal caused a JavaScript syntax error that prevented the app from initializing and left the loader spinning.
- The change touches a runtime asset (`index.html`), so the service worker caches must be bumped to ensure clients pick up the fix.
- Preserve timetable content while restoring valid JS so the UI can boot normally.

### Description
- Removed the erroneous terminator at the end of the `rawData` template literal in `index.html`, fixing the line to end with a single closing backtick and semicolon (`\`;`).
- The exact fixed location is `index.html` line 425 where the broken ``;`;` was replaced with ``;`.
- Bumped `CACHE_NAME` and `STATIC_CACHE_NAME` in `sw.js` from `vpps-timetable-v32` / `vpps-static-v32` to `vpps-timetable-v33` / `vpps-static-v33` to force cache refresh for the corrected runtime shell.

### Testing
- Ran `node build-report.js` and it completed successfully and regenerated the build report.
- Ran `node tests/manual/test-mapping.js` and it passed (26 passed, 0 failed).
- Ran `node tests/manual/colors/verify-contrast.js` and all color contrast checks passed (WCAG AA).
- Started a local server with `npx http-server . -p 8080 -c-1` and confirmed an HTTP 200 response from `http://127.0.0.1:8080` and that the served HTML contains the corrected `const rawData` terminator (no ``;`;` present), so the syntax error that blocked initialization is removed; the app can now load locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2c6a52cd88324bf4e478861622ad1)