### PR TITLE
Enforce strict timetable parsing schema and runtime token guards

### DIFF
--- a/docs/reports/build-report.json
+++ b/docs/reports/build-report.json
@@ -1,11 +1,11 @@
 {
-  "timestamp": "2026-04-29T15:43:14.759Z",
+  "timestamp": "2026-04-30T03:45:57.932Z",
   "files": [
     {
       "file": "index.html",
-      "rawSize": 208825,
-      "gzippedSize": 46221,
-      "compression": "77.9%"
+      "rawSize": 209855,
+      "gzippedSize": 46520,
+      "compression": "77.8%"
     },
     {
       "file": "scripts/perf.js",
@@ -69,7 +69,7 @@
     }
   ],
   "totals": {
-    "raw": 357881,
-    "gzipped": 81084
+    "raw": 358911,
+    "gzipped": 81383
   }
 }

--- a/index.html
+++ b/index.html
@@ -1386,6 +1386,11 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 			const timetable = {};
 			const teacherDetails = {};
 			let headers = [];
+			const expectedDayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+			const expectedHeaderRow = ['Class', 'Period 1', 'Period 2', 'Period 3', 'Period 4', 'Period 5', 'Period 6'];
+			const expectedClassColumnCount = 7;
+			const expectedClassesPerDay = 16;
+			const forbiddenRuntimeTokens = ['Assembly', 'Period 7', 'Period 8', 'Director', 'Games', 'Sports', 'PT', 'Robotics', 'NoteBook'];
 
 			try {
 				// Validate rawData exists
@@ -1407,7 +1412,7 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 					.map(line => line.trim())           // Trim whitespace from each line
 					.filter(line => line.length > 0);   // Remove empty lines
 
-				const dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+				const dayNames = expectedDayNames;
 				
 				let currentDay = null;
 				let currentDayData = [];
@@ -1439,12 +1444,12 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 
 				function processDay(day, dayData) {
 					if (!dayData || dayData.length === 0) {
-						console.warn(`No data found for ${day}`);
-						return;
+						throw new Error(`No data found for day ${day}`);
 					}
 
 					timetable[day] = {};
 					let headerProcessed = false;
+					let classRowsProcessed = 0;
 					
 					// Process each line for this day
 					for (let lineIndex = 0; lineIndex < dayData.length; lineIndex++) {
@@ -1468,15 +1473,14 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 						);
 						
 						if (isHeaderRow) {
-							console.log(`Skipping header: ${day} - "${line.substring(0, 100)}..."`);
-							
-							// Process headers only once across all days
-							if (headers.length === 0 && line.includes('Period 1')) {
-								headers = columns
-									.slice(1)
-									.map(h => ({ name: h.trim(), time: '' }));
-								console.log(`Headers extracted: ${headers.length} periods`);
+							if (columns.length !== expectedHeaderRow.length) {
+								throw new Error(`Invalid header column count on ${day}: found ${columns.length}, expected ${expectedHeaderRow.length}`);
 							}
+							const mismatchIndex = columns.findIndex((col, index) => col !== expectedHeaderRow[index]);
+							if (mismatchIndex !== -1) {
+								throw new Error(`Invalid header on ${day}: "${columns.join(',')}"`);
+							}
+							headers = expectedHeaderRow.slice(1).map(h => ({ name: h, time: '' }));
 							headerProcessed = true;
 							continue; // CRITICAL: Skip processing this line as class data
 						}
@@ -1489,9 +1493,8 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 							console.log(`Processing class: ${day} - "${className}" with ${columns.length-1} periods`);
 							
 							// Ensure we have enough columns for all periods
-							if (columns.length < 2) {
-								console.warn(`Insufficient data for ${className} on ${day}`);
-								continue;
+							if (columns.length !== expectedClassColumnCount) {
+								throw new Error(`Invalid column count for ${className} on ${day}: found ${columns.length}, expected ${expectedClassColumnCount}`);
 							}
 							
 							// Initialize the class schedule array
@@ -1604,6 +1607,7 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 									});
 								}
 							});
+							classRowsProcessed++;
 						} else {
 							// Debug: Log any unprocessed lines
 							console.log(`Unprocessed line: ${day} - "${line.substring(0, 100)}..."`);
@@ -1613,8 +1617,13 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 							console.log(`   No 'period': ${!firstColumn.toLowerCase().includes('period')}`);
 						}
 					}
-					
-					console.log(`Processed ${day}: ${Object.keys(timetable[day]).length} classes`);
+
+					if (!headerProcessed) {
+						throw new Error(`Missing header row for ${day}`);
+					}
+					if (classRowsProcessed !== expectedClassesPerDay) {
+						throw new Error(`Day ${day} has ${classRowsProcessed} class rows; expected ${expectedClassesPerDay}`);
+					}
 				}
 
 				// Validate and clean up the parsed data
@@ -1634,6 +1643,24 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 				// Update timetable reference
 				Object.keys(timetable).forEach(key => delete timetable[key]);
 				Object.assign(timetable, cleanTimetable);
+				const missingDays = expectedDayNames.filter(day => !Object.prototype.hasOwnProperty.call(timetable, day));
+				if (missingDays.length > 0) {
+					throw new Error(`Missing required day(s): ${missingDays.join(', ')}`);
+				}
+
+				const forbiddenPattern = new RegExp(`\\b(?:${forbiddenRuntimeTokens.join('|')})\\b`, 'i');
+				for (const [day, dayRows] of Object.entries(timetable)) {
+					for (const [className, entries] of Object.entries(dayRows)) {
+						entries.forEach((entry, periodIndex) => {
+							const periodLabel = headers[periodIndex]?.name || `Period ${periodIndex + 1}`;
+							const subjectText = String(entry?.subject || '');
+							const teacherText = String(entry?.teacher || '');
+							if (forbiddenPattern.test(subjectText) || forbiddenPattern.test(teacherText) || forbiddenPattern.test(periodLabel)) {
+								throw new Error(`Forbidden token in runtime data at ${day} > ${className} > ${periodLabel}`);
+							}
+						});
+					}
+				}
 
 				// Enhanced class sorting with better filtering
 				let allClassNames = new Set();
@@ -1696,20 +1723,6 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 				console.log('Teachers found:', validTeacherNames.length);
 				console.log('Period headers:', headers.length);
 				
-				// Validate data integrity
-				validDays.forEach(day => {
-					const dayClasses = Object.keys(timetable[day]);
-					console.log(`${day}: ${dayClasses.length} classes`);
-					
-					// Check for data consistency
-					dayClasses.forEach(className => {
-						const periods = timetable[day][className];
-						if (periods.length !== headers.length && headers.length > 0) {
-							console.warn(`${day} ${className}: Expected ${headers.length} periods, got ${periods.length}`);
-						}
-					});
-				});
-				
 				// Cache the result
 				state.cache.set('parsedData', result);
 				state.lastUpdate = Date.now();
@@ -1720,16 +1733,7 @@ Class 12 Arts,Geography (Prakash),English Literature (Harshita),Economics (Praka
 				console.error('Error parsing timetable data:', error);
 				console.error('Error details:', error.message);
 				console.error('Stack trace:', error.stack);
-				
-				// Return minimal data structure to prevent crashes
-				return {
-					timetable: { Monday: {} },
-					teacherDetails: {},
-					periodHeaders: [],
-					classNames: [],
-					teacherNames: [],
-					days: ['Monday']
-				};
+				throw error;
 			}
 		};
 

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // Service Worker for Veer Patta Public School Timetable
 // Provides offline-first caching for the page shell and timetable data
 
-const CACHE_NAME = 'vpps-timetable-v33';
-const STATIC_CACHE_NAME = 'vpps-static-v33';
+const CACHE_NAME = 'vpps-timetable-v34';
+const STATIC_CACHE_NAME = 'vpps-static-v34';
 
 // Core resources required for offline shell
 const CORE_ASSETS = [


### PR DESCRIPTION
### Motivation
- Ensure the timetable parser strictly enforces the expected 6-period runtime CSV shape and fails fast on malformed input instead of silently continuing with a fallback dataset.
- Make parse-time errors fatal so the existing UI fatal fallback shows loader removal and an error message, avoiding inconsistent runtime state.
- Prevent unsupported or legacy tokens from appearing in active runtime data to avoid downstream view/logic corruption.
- Invalidate service-worker caches after runtime changes so clients get the updated parser and runtime assets.

### Description
- Tightened `parseTimetableData()` / `processDay(...)` to require an exact header row `Class,Period 1,Period 2,Period 3,Period 4,Period 5,Period 6`, exact class row width of 7 CSV columns, presence of Monday–Saturday, and exactly 16 class rows per day, and to throw `Error` with contextual day/class information on violations.
- Added runtime guards that scan parsed timetable entries and throw `Error` if any active data contains forbidden tokens: `Assembly`, `Period 7`, `Period 8`, `Director`, `Games`, `Sports`, `PT`, `Robotics`, or `NoteBook`.
- Changed parse error handling to rethrow errors (instead of returning a minimal synthetic dataset) so `init()`’s existing fatal UI fallback handles the failure (loader removal + error UI).
- Bumped service worker cache names in `sw.js` (`v33` → `v34`) and regenerated the build report after the runtime edits.

### Testing
- Ran `node build-report.js`, which completed successfully and produced an updated `docs/reports/build-report.json`.
- Ran `node tests/manual/test-mapping.js`, which passed (`26 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2d016d7448324a5fae7b5d052ec5a)