### PR TITLE
Bump SW cache names to v34 and add admin post-deploy refresh note

### DIFF
--- a/docs/guides/SERVICE_WORKER_TESTING.md
+++ b/docs/guides/SERVICE_WORKER_TESTING.md
@@ -137,6 +137,16 @@ Run this after changing any cached asset:
 - verify the affected UI path
 - verify the app still opens offline
 
+
+## Admin Release Note (Post-Deploy)
+
+After deploying a new service worker version, administrators should do one of the following if an older worker still controls the app:
+
+- perform one hard refresh (`Ctrl+Shift+R` on Windows/Linux or `Cmd+Shift+R` on macOS)
+- clear site data in DevTools (Application → Storage → Clear site data)
+
+This forces clients onto the latest cache version and avoids stale shell assets.
+
 ## Troubleshooting
 
 ### Changes do not appear

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // Service Worker for Veer Patta Public School Timetable
 // Provides offline-first caching for the page shell and timetable data
 
-const CACHE_NAME = 'vpps-timetable-v33';
-const STATIC_CACHE_NAME = 'vpps-static-v33';
+const CACHE_NAME = 'vpps-timetable-v34';
+const STATIC_CACHE_NAME = 'vpps-static-v34';
 
 // Core resources required for offline shell
 const CORE_ASSETS = [


### PR DESCRIPTION
### Motivation

- Ensure clients pick up the updated runtime assets by bumping the service worker cache names after a runtime change and provide administrators with a short post-deploy action to avoid stale controlling workers.

### Description

- Updated `CACHE_NAME` from `vpps-timetable-v33` to `vpps-timetable-v34` and `STATIC_CACHE_NAME` from `vpps-static-v33` to `vpps-static-v34` in `sw.js`.
- Kept the existing activation cleanup logic so it continues to delete all caches except the two current names (`CACHE_NAME` and `STATIC_CACHE_NAME`).
- Preserved the current update lifecycle calls (`self.skipWaiting()` in install and `self.clients.claim()` in activate).
- Added an admin-facing release note to `docs/guides/SERVICE_WORKER_TESTING.md` recommending a hard refresh or clearing site data post-deploy if an old worker still controls clients.

### Testing

- Ran `rg` to confirm the new `CACHE_NAME`/`STATIC_CACHE_NAME` occurrences and the inserted admin note and found the expected changes (succeeded).
- Inspected the modified `sw.js` lines to verify the cleanup condition and presence of `skipWaiting`/`clients.claim` (succeeded).
- Performed `git diff` to review diffs and committed the changes with a descriptive message (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2d018f1588324a0bf9b54eb731e26)